### PR TITLE
Feature/22 fix publishing of fluent contents

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,25 @@
   * Fix a bug where looking for help_text in a placeholder slot that had no
     manual configuration raised a 500, resulting in no layout data found
 
+  * Fix bug where the content items and placeholders associated with a
+    fluent content model (other than a page) were not included in the
+    published copy.
+
+  * Provide `icekit.publishing.models.PublishableFluentContents` and
+    `icekit.publishing.admin.PublishableFluentContentsAdmin` as base
+    classes for fluent content models and admins, to help keep things
+    DRY.
+
+### Breaking changes
+
+  * Import model mixins `FluentFieldsMixin`, `LayoutFieldMixin`, and
+    `ReadabilityMixin` from `icekit.mixins` module instead of
+    `icekit.abstract_models`.
+
+  * Import admin mixin `FluentLayoutsMixin` from `icekit.admin_mixins`
+    module instead of `icekit.admin`.
+
+
 
 ## 0.14 (20 September 2016)
 

--- a/docs/howto/page-types.md
+++ b/docs/howto/page-types.md
@@ -83,7 +83,7 @@ Here's a rough guide:
 | Static               | Yes                     | No          | `FluentContentsPage`                                      | `FluentContentsPageAdmin`                      |
 | Static               | Yes                     | Yes         | `PublishableFluentContentsPage` (use `PlaceholderField`s) | `(FluentContentsPageAdmin, PublishingAdmin)`   |
 | Dynamic              | No                      | No          | `FluentFieldsMixin`                                       | `FluentLayoutsMixin`                           |
-| Dynamic              | No                      | Yes         | `(FluentFieldsMixin, PublishingModel)`                    | `(FluentLayoutsMixin, PublishingAdmin)`        |
+| Dynamic              | No                      | Yes         | `PublishableFluentContents`                               | `PublishableFluentContentsAdmin`               |
 | Dynamic              | Yes                     | No          | `AbstractUnpublishableLayoutPage`                         | `UnpublishableLayoutPageAdmin`                 |
 | Dynamic              | Yes                     | Yes         | `AbstractLayoutPage`                                      | `LayoutPageAdmin`                              |
 

--- a/docs/howto/plugins.md
+++ b/docs/howto/plugins.md
@@ -81,7 +81,7 @@ with two mixin classes:
 
     # admin.py
 
-    from icekit.admin import FluentLayoutsMixin
+    from icekit.admin_mixins import FluentLayoutsMixin
 
     class MyModelAdmin(FluentLayoutsMixin, MyModelAdminBase):
         ...

--- a/docs/howto/plugins.md
+++ b/docs/howto/plugins.md
@@ -74,7 +74,7 @@ with two mixin classes:
 
     # models.py
 
-    from icekit.abstract_models import FluentFieldsMixin
+    from icekit.mixins import FluentFieldsMixin
 
     class MyModel(FluentFieldsMixin, MyModelBase):
         ...

--- a/docs/topics/publishing.md
+++ b/docs/topics/publishing.md
@@ -41,6 +41,11 @@ To make a `FluentContentsPage` model publishable:
 * subclass your model from `icekit.publishing.models.PublishableFluentContentsPage`
 * subclass your model's admin from `FluentContentsPageAdmin` and `icekit.publishing.admin.PublishingAdmin`
 
+To make a fluent contents model (see [ContentsPlugins]) publishable:
+
+* subclass your model from `icekit.publishing.models.PublishableFluentContents`
+* subclass your model's admin from `icekit.publishing.admin.PublishableFluentContentsAdmin`
+
 #### Note: Validating slug uniqueness
 
 In publishable models, both the draft and published slugs will be identical,
@@ -225,3 +230,5 @@ rendering related content for the public and for site admins:
 There has been an issue discovered where `ManyToMany` fields referring both
 ways on models have the many to many data cloned for published and
 unpublished objects. This is currently being worked on.
+
+[ContentsPlugins]: ../howto/plugins.md

--- a/icekit/abstract_models.py
+++ b/icekit/abstract_models.py
@@ -5,120 +5,12 @@ Models for ``icekit`` app.
 # Compose concrete models from abstract models and mixins, to facilitate reuse.
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.template.defaultfilters import striptags
 from django.template.loader import get_template
 from django.utils import encoding, timezone
 from django.utils.translation import ugettext_lazy as _
 from fluent_contents.analyzer import get_template_placeholder_data
-from fluent_contents.models import \
-    ContentItemRelation, Placeholder, PlaceholderRelation
-from fluent_contents.rendering import render_content_items
-from icekit.tasks import store_readability_score
-from icekit.utils.readability.readability import Readability
-from unidecode import unidecode
 
 from . import fields, plugins
-
-
-# MIXINS ######################################################################
-
-
-class LayoutFieldMixin(models.Model):
-    """
-    Add ``layout`` field to models that already have ``contentitem_set`` and
-    ``placeholder_set`` fields.
-    """
-    layout = models.ForeignKey(
-        'icekit.Layout',
-        blank=True,
-        null=True,
-        related_name='%(app_label)s_%(class)s_related',
-    )
-
-    fallback_template = 'icekit/layouts/fallback_default.html'
-
-    class Meta:
-        abstract = True
-
-    def get_layout_template_name(self):
-        """
-        Return ``layout.template_name`` or `fallback_template``.
-        """
-        if self.layout:
-            return self.layout.template_name
-        return self.fallback_template
-
-
-class FluentFieldsMixin(LayoutFieldMixin):
-    """
-    Add ``layout``, ``contentitem_set`` and ``placeholder_set`` fields so we
-    can add modular content with ``django-fluent-contents``.
-    """
-    contentitem_set = ContentItemRelation()
-    placeholder_set = PlaceholderRelation()
-
-    class Meta:
-        abstract = True
-
-    # HACK: This is needed to work-around a `django-fluent-contents` issue
-    # where it cannot handle placeholders being added to a template after an
-    # object already has placeholder data in the database.
-    # See: https://github.com/edoburu/django-fluent-contents/pull/63
-    def add_missing_placeholders(self):
-        """
-        Add missing placeholders from templates. Return `True` if any missing
-        placeholders were created.
-        """
-        content_type = ContentType.objects.get_for_model(self)
-        result = False
-        if self.layout:
-            for data in self.layout.get_placeholder_data():
-                placeholder, created = Placeholder.objects.update_or_create(
-                    parent_type=content_type,
-                    parent_id=self.pk,
-                    slot=data.slot,
-                    defaults=dict(
-                        role=data.role,
-                        title=data.title,
-                    ))
-                result = result or created
-        return result
-
-    def placeholders(self):
-        # return a dict of placeholders, organised by slot, for access in templates
-        # use `page.placeholders.<slot_name>.get_content_items` to test if
-        # a placeholder has any items.
-        return dict([(p.slot, p) for p in self.placeholder_set.all().select_related()])
-
-
-# TODO: should be a sub-app.
-class ReadabilityMixin(models.Model):
-    readability_score = models.DecimalField(max_digits=4, decimal_places=2, null=True)
-
-    class Meta:
-        abstract = True
-
-    def extract_text(self):
-        # return the rendered content, with HTML tags stripped.
-        html = render_content_items(request=None, items=self.contentitem_set.all())
-        return striptags(html)
-
-    def calculate_readability_score(self):
-        try:
-            return Readability(unidecode(self.extract_text())).SMOGIndex()
-        except:
-            return None
-
-    def store_readability_score(self):
-        store_readability_score.delay(self._meta.app_label, self._meta.model_name, self.pk)
-
-    def save(self, *args, **kwargs):
-        r = super(ReadabilityMixin, self).save(*args, **kwargs)
-        self.store_readability_score()
-        return r
-
-
-# MODELS ######################################################################
 
 
 class AbstractBaseModel(models.Model):

--- a/icekit/admin.py
+++ b/icekit/admin.py
@@ -10,9 +10,6 @@ from django.contrib import admin
 from django.contrib.contenttypes.models import ContentType
 from django.http import JsonResponse
 from django.utils.translation import ugettext_lazy as _
-from fluent_contents.admin import PlaceholderEditorAdmin
-from fluent_contents.analyzer import get_template_placeholder_data
-from fluent_contents.models import PlaceholderData
 from polymorphic.admin import PolymorphicParentModelAdmin
 
 from icekit import models
@@ -42,37 +39,6 @@ class ChildModelFilter(admin.SimpleListFilter):
 
 
 # MIXINS ######################################################################
-
-
-class FluentLayoutsMixin(PlaceholderEditorAdmin):
-    """
-    Mixin class for models that have a ``layout`` field and fluent content.
-    """
-
-    change_form_template = 'icekit/admin/fluent_layouts_change_form.html'
-
-    class Media:
-        js = ('icekit/admin/js/fluent_layouts.js', )
-
-    def formfield_for_foreignkey(self, db_field, *args, **kwargs):
-        """
-        Update queryset for ``layout`` field.
-        """
-        formfield = super(FluentLayoutsMixin, self).formfield_for_foreignkey(
-            db_field, *args, **kwargs)
-        if db_field.name == 'layout':
-            formfield.queryset = formfield.queryset.for_model(self.model)
-        return formfield
-
-    def get_placeholder_data(self, request, obj):
-        """
-        Get placeholder data from layout.
-        """
-        if not obj or not obj.layout:
-            data = [PlaceholderData(slot='main', role='m', title='Main')]
-        else:
-            data = obj.layout.get_placeholder_data()
-        return data
 
 
 class ChildModelPluginPolymorphicParentModelAdmin(PolymorphicParentModelAdmin):

--- a/icekit/admin_mixins.py
+++ b/icekit/admin_mixins.py
@@ -1,0 +1,33 @@
+from fluent_contents.admin import PlaceholderEditorAdmin
+from fluent_contents.models import PlaceholderData
+
+
+class FluentLayoutsMixin(PlaceholderEditorAdmin):
+    """
+    Mixin class for models that have a ``layout`` field and fluent content.
+    """
+
+    change_form_template = 'icekit/admin/fluent_layouts_change_form.html'
+
+    class Media:
+        js = ('icekit/admin/js/fluent_layouts.js', )
+
+    def formfield_for_foreignkey(self, db_field, *args, **kwargs):
+        """
+        Update queryset for ``layout`` field.
+        """
+        formfield = super(FluentLayoutsMixin, self).formfield_for_foreignkey(
+            db_field, *args, **kwargs)
+        if db_field.name == 'layout':
+            formfield.queryset = formfield.queryset.for_model(self.model)
+        return formfield
+
+    def get_placeholder_data(self, request, obj):
+        """
+        Get placeholder data from layout.
+        """
+        if not obj or not obj.layout:
+            data = [PlaceholderData(slot='main', role='m', title='Main')]
+        else:
+            data = obj.layout.get_placeholder_data()
+        return data

--- a/icekit/articles/abstract_models.py
+++ b/icekit/articles/abstract_models.py
@@ -1,12 +1,6 @@
-from icekit.abstract_models import FluentFieldsMixin
-from icekit.publishing.models import PublishingModel
+from icekit.publishing.models import PublishableFluentModel
 from django.db import models
 
-# TODO: this should ideally be in icekit.abstract_models, but doing so
-# creates circular import errors.
-class PublishableFluentModel(FluentFieldsMixin, PublishingModel):
-    class Meta:
-        abstract = True
 
 class TitleSlugMixin(models.Model):
     # TODO: this should perhaps become part of a wider ICEkit mixin that covers

--- a/icekit/articles/abstract_models.py
+++ b/icekit/articles/abstract_models.py
@@ -1,4 +1,4 @@
-from icekit.publishing.models import PublishableFluentModel
+from icekit.publishing.models import PublishableFluentContents
 from django.db import models
 
 
@@ -16,7 +16,7 @@ class TitleSlugMixin(models.Model):
         return self.title
 
 
-class PublishableArticle(PublishableFluentModel, TitleSlugMixin):
+class PublishableArticle(PublishableFluentContents, TitleSlugMixin):
     '''
     Basic Article type (ie that forms the basis of independent collections of
     publishable things).
@@ -24,4 +24,3 @@ class PublishableArticle(PublishableFluentModel, TitleSlugMixin):
 
     class Meta:
         abstract = True
-

--- a/icekit/articles/admin.py
+++ b/icekit/articles/admin.py
@@ -3,7 +3,8 @@ from django.contrib import admin
 from icekit.admin import FluentLayoutsMixin
 from icekit.publishing.admin import PublishingAdmin
 
-class PublishableFluentModelAdmin(PublishingAdmin, FluentLayoutsMixin):
+
+class PublishableFluentContentsAdmin(PublishingAdmin, FluentLayoutsMixin):
     """
     Add publishing features for non-Page rich content models
     """
@@ -14,5 +15,5 @@ class TitleSlugAdmin(admin.ModelAdmin):
     prepopulated_fields = {"slug": ("title",)}
 
 
-class PublishableArticleAdmin(PublishableFluentModelAdmin, TitleSlugAdmin):
+class PublishableArticleAdmin(PublishableFluentContentsAdmin, TitleSlugAdmin):
     pass

--- a/icekit/articles/admin.py
+++ b/icekit/articles/admin.py
@@ -1,14 +1,6 @@
 from django.contrib import admin
 
-from icekit.admin import FluentLayoutsMixin
-from icekit.publishing.admin import PublishingAdmin
-
-
-class PublishableFluentContentsAdmin(PublishingAdmin, FluentLayoutsMixin):
-    """
-    Add publishing features for non-Page rich content models
-    """
-    pass
+from icekit.publishing.admin import PublishableFluentContentsAdmin
 
 
 class TitleSlugAdmin(admin.ModelAdmin):

--- a/icekit/management/commands/add_missing_placeholders.py
+++ b/icekit/management/commands/add_missing_placeholders.py
@@ -1,7 +1,7 @@
 from django.apps import apps
 from django.core.management.base import NoArgsCommand
 from django.utils.encoding import force_text
-from icekit.abstract_models import FluentFieldsMixin
+from icekit.mixins import FluentFieldsMixin
 
 
 class Command(NoArgsCommand):

--- a/icekit/mixins.py
+++ b/icekit/mixins.py
@@ -1,0 +1,114 @@
+from unidecode import unidecode
+
+from django.db import models
+from django.contrib.contenttypes.models import ContentType
+from django.template.defaultfilters import striptags
+
+from fluent_contents.models import \
+    ContentItemRelation, Placeholder, PlaceholderRelation
+from fluent_contents.rendering import render_content_items
+
+from icekit.tasks import store_readability_score
+from icekit.utils.readability.readability import Readability
+
+
+class LayoutFieldMixin(models.Model):
+    """
+    Add ``layout`` field to models that already have ``contentitem_set`` and
+    ``placeholder_set`` fields.
+    """
+    layout = models.ForeignKey(
+        'icekit.Layout',
+        blank=True,
+        null=True,
+        related_name='%(app_label)s_%(class)s_related',
+    )
+
+    fallback_template = 'icekit/layouts/fallback_default.html'
+
+    class Meta:
+        abstract = True
+
+    def get_layout_template_name(self):
+        """
+        Return ``layout.template_name`` or `fallback_template``.
+        """
+        if self.layout:
+            return self.layout.template_name
+        return self.fallback_template
+
+
+class FluentFieldsMixin(LayoutFieldMixin):
+    """
+    Add ``layout``, ``contentitem_set`` and ``placeholder_set`` fields so we
+    can add modular content with ``django-fluent-contents``.
+    """
+    contentitem_set = ContentItemRelation()
+    placeholder_set = PlaceholderRelation()
+
+    class Meta:
+        abstract = True
+
+    # HACK: This is needed to work-around a `django-fluent-contents` issue
+    # where it cannot handle placeholders being added to a template after an
+    # object already has placeholder data in the database.
+    # See: https://github.com/edoburu/django-fluent-contents/pull/63
+    def add_missing_placeholders(self):
+        """
+        Add missing placeholders from templates. Return `True` if any missing
+        placeholders were created.
+        """
+        content_type = ContentType.objects.get_for_model(self)
+        result = False
+        if self.layout:
+            for data in self.layout.get_placeholder_data():
+                placeholder, created = Placeholder.objects.update_or_create(
+                    parent_type=content_type,
+                    parent_id=self.pk,
+                    slot=data.slot,
+                    defaults=dict(
+                        role=data.role,
+                        title=data.title,
+                    ))
+                result = result or created
+        return result
+
+    def placeholders(self):
+        # return a dict of placeholders, organised by slot, for access in
+        # templates use `page.placeholders.<slot_name>.get_content_items` to
+        # test if a placeholder has any items.
+        return dict([(p.slot, p)
+                     for p in self.placeholder_set.all().select_related()])
+
+
+# TODO: should be a sub-app.
+class ReadabilityMixin(models.Model):
+    readability_score = models.DecimalField(
+        max_digits=4,
+        decimal_places=2,
+        null=True
+    )
+
+    class Meta:
+        abstract = True
+
+    def extract_text(self):
+        # return the rendered content, with HTML tags stripped.
+        html = render_content_items(
+            request=None, items=self.contentitem_set.all())
+        return striptags(html)
+
+    def calculate_readability_score(self):
+        try:
+            return Readability(unidecode(self.extract_text())).SMOGIndex()
+        except:
+            return None
+
+    def store_readability_score(self):
+        store_readability_score.delay(
+            self._meta.app_label, self._meta.model_name, self.pk)
+
+    def save(self, *args, **kwargs):
+        r = super(ReadabilityMixin, self).save(*args, **kwargs)
+        self.store_readability_score()
+        return r

--- a/icekit/page_types/layout_page/abstract_models.py
+++ b/icekit/page_types/layout_page/abstract_models.py
@@ -1,7 +1,7 @@
 from fluent_pages.integration.fluent_contents import FluentContentsPage
 
 from icekit.publishing.models import PublishableFluentContentsPage
-from icekit.abstract_models import LayoutFieldMixin
+from icekit.mixins import LayoutFieldMixin
 
 
 class AbstractUnpublishableLayoutPage(FluentContentsPage, LayoutFieldMixin):

--- a/icekit/page_types/layout_page/admin.py
+++ b/icekit/page_types/layout_page/admin.py
@@ -1,6 +1,6 @@
 from fluent_pages.integration.fluent_contents.admin import FluentContentsPageAdmin
 
-from icekit.admin import FluentLayoutsMixin
+from icekit.admin_mixins import FluentLayoutsMixin
 from icekit.publishing.admin import PublishingAdmin
 
 

--- a/icekit/publishing/admin.py
+++ b/icekit/publishing/admin.py
@@ -16,9 +16,11 @@ from django.utils.translation import ugettext_lazy as _
 from django.template import loader, Context
 
 from fluent_pages.models.db import UrlNode
-from fluent_pages.adminui.pageadmin import DefaultPageChildAdmin, \
-    _select_template_name
+from fluent_pages.adminui.pageadmin import _select_template_name
 from fluent_pages.adminui.urlnodeparentadmin import UrlNodeParentAdmin
+
+from icekit.admin_mixins import FluentLayoutsMixin
+
 from .models import PublishingModel
 
 
@@ -636,3 +638,10 @@ class ICEKitFluentPagesParentAdminMixin(
 ):
     """ Add publishing features for FluentPage parent admin (listing) pages """
     list_filter = (PublishingStatusFilter, PublishingPublishedFilter)
+
+
+class PublishableFluentContentsAdmin(PublishingAdmin, FluentLayoutsMixin):
+    """
+    Add publishing admin features for models with Fluent Contents features
+    """
+    pass

--- a/icekit/publishing/models.py
+++ b/icekit/publishing/models.py
@@ -267,9 +267,9 @@ class PublishingModel(models.Model):
 
             # As it is a new object we need to clone each of the
             # translatable fields, placeholders and required relations.
-            self.clone_translations(publish_obj)
-            self.clone_placeholder(publish_obj)
-            self.clone_relations(publish_obj)
+            self.clone_parler_translations(publish_obj)
+            self.clone_fluent_placeholders(publish_obj)
+            self.clone_fluent_contentitems(publish_obj)
 
             # Extra relationship-cloning smarts
             publish_obj.publishing_clone_relations(self)
@@ -458,7 +458,7 @@ class PublishingModel(models.Model):
                 published_placeholder.pk = None
                 published_placeholder.save()
 
-    def clone_translations(self, dst_obj):
+    def clone_parler_translations(self, dst_obj):
         """
         Clone each of the translations from an object and relate
         them to another.
@@ -483,7 +483,7 @@ class PublishingModel(models.Model):
                 translation.master = dst_obj
                 translation.save()
 
-    def clone_placeholder(self, dst_obj):
+    def clone_fluent_placeholders(self, dst_obj):
         """
         Clone each of the placeholder items.
 
@@ -507,7 +507,7 @@ class PublishingModel(models.Model):
             src_items = src_placeholder.get_content_items()
             src_items.copy_to_placeholder(dst_placeholder)
 
-    def clone_relations(self, dst_obj):
+    def clone_fluent_contentitems(self, dst_obj):
         """
         Find all MTM relationships on related ContentItem's and ensure the
         published M2M relationships directed back to the draft (src)

--- a/icekit/publishing/models.py
+++ b/icekit/publishing/models.py
@@ -556,7 +556,7 @@ class PublishableFluentContentsPage(FluentContentsPage,
         abstract = True
 
 
-class PublishableFluentModel(FluentFieldsMixin, PublishingModel):
+class PublishableFluentContents(FluentFieldsMixin, PublishingModel):
 
     class Meta:
         abstract = True

--- a/icekit/publishing/models.py
+++ b/icekit/publishing/models.py
@@ -268,8 +268,8 @@ class PublishingModel(models.Model):
             # As it is a new object we need to clone each of the
             # translatable fields, placeholders and required relations.
             self.clone_parler_translations(publish_obj)
-            self.clone_fluent_placeholders(publish_obj)
-            self.clone_fluent_contentitems(publish_obj)
+            self.clone_fluent_placeholders_and_content_items(publish_obj)
+            self.clone_fluent_contentitems_m2m_relationships(publish_obj)
 
             # Extra relationship-cloning smarts
             publish_obj.publishing_clone_relations(self)
@@ -483,19 +483,16 @@ class PublishingModel(models.Model):
                 translation.master = dst_obj
                 translation.save()
 
-    def clone_fluent_placeholders(self, dst_obj):
+    def clone_fluent_placeholders_and_content_items(self, dst_obj):
         """
-        Clone each of the placeholder items.
+        Clone each `Placeholder` and its `ContentItem`s.
 
-        :param self: The object which does not get used...
         :param self: The object for which the placeholders are
         to be cloned from.
         :param dst_obj: The object which the cloned placeholders
         are to be related.
         :return: None
         """
-        if not isinstance(self, FluentContentsPage):
-            return
         for src_placeholder in Placeholder.objects.parent(self):
             dst_placeholder = Placeholder.objects.create_for_object(
                 dst_obj,
@@ -507,7 +504,7 @@ class PublishingModel(models.Model):
             src_items = src_placeholder.get_content_items()
             src_items.copy_to_placeholder(dst_placeholder)
 
-    def clone_fluent_contentitems(self, dst_obj):
+    def clone_fluent_contentitems_m2m_relationships(self, dst_obj):
         """
         Find all MTM relationships on related ContentItem's and ensure the
         published M2M relationships directed back to the draft (src)

--- a/icekit/publishing/models.py
+++ b/icekit/publishing/models.py
@@ -11,6 +11,8 @@ from fluent_contents.models import Placeholder
 from fluent_pages.models import UrlNode
 from fluent_pages.integration.fluent_contents import FluentContentsPage
 
+from icekit.mixins import FluentFieldsMixin
+
 from .managers import PublishingManager, PublishingUrlNodeManager
 from .middleware import is_draft_request_context
 from .utils import PublishingException, assert_draft
@@ -549,6 +551,12 @@ class PublishableFluentContentsPage(FluentContentsPage,
     @property
     def is_published(self):
         return not self.publishing_is_draft
+
+    class Meta:
+        abstract = True
+
+
+class PublishableFluentModel(FluentFieldsMixin, PublishingModel):
 
     class Meta:
         abstract = True

--- a/icekit/tests/models.py
+++ b/icekit/tests/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from fluent_pages.extensions import page_type_pool
 
-from icekit import abstract_models
+from icekit import abstract_models, mixins
 from icekit.articles.abstract_models import PublishableArticle
 from icekit.page_types.layout_page.abstract_models import \
     AbstractLayoutPage, AbstractUnpublishableLayoutPage
@@ -19,15 +19,15 @@ class BaseModel(abstract_models.AbstractBaseModel):
     pass
 
 
-class FooWithLayout(abstract_models.LayoutFieldMixin):
+class FooWithLayout(mixins.LayoutFieldMixin):
     pass
 
 
-class BarWithLayout(abstract_models.LayoutFieldMixin):
+class BarWithLayout(mixins.LayoutFieldMixin):
     pass
 
 
-class BazWithLayout(abstract_models.LayoutFieldMixin):
+class BazWithLayout(mixins.LayoutFieldMixin):
     pass
 
 

--- a/icekit/tests/tests.py
+++ b/icekit/tests/tests.py
@@ -21,7 +21,7 @@ from fluent_contents.plugins.rawhtml.models import RawHtmlItem
 from fluent_pages.models import PageLayout
 from fluent_pages.pagetypes.fluentpage.models import FluentPage
 from forms_builder.forms.models import Form
-from icekit.abstract_models import LayoutFieldMixin
+from icekit.mixins import LayoutFieldMixin
 from icekit.page_types.layout_page.models import LayoutPage
 from icekit.plugins import descriptors
 from icekit.plugins.faq.models import FAQItem


### PR DESCRIPTION
Publishing of arbitrary items with placeholders and content items is now supported, not just Fluent Contents Page items.

Unit tests are also improved to confirm cloning of this data happens as expected when a Fluent Contents Page or Fluent Contents item in general is published.