### PR TITLE
Add a hook to inject uncompressed js

### DIFF
--- a/icekit/templates/icekit/base.html
+++ b/icekit/templates/icekit/base.html
@@ -78,6 +78,8 @@
 			{% compress js file %}
 				{% block js %}{% endblock %}
 			{% endcompress %}
+			{# JS files and <script> elements that must remain uncompressed #}
+			{% block uncompressed_js %}{% endblock %}
 		{% endblock %}
 	</body>
 </html>


### PR DESCRIPTION
While the `body_js` and `external_js` blocks can be overridden, you cannot do so **and** use any global libraries that have been added.