### PR TITLE
Add commands to manage MPTT issues and syncing for publishing #184

### DIFF
--- a/icekit/management/commands/print_mptt_tree.py
+++ b/icekit/management/commands/print_mptt_tree.py
@@ -1,0 +1,76 @@
+from optparse import make_option
+
+from django.core.management.base import NoArgsCommand
+from django.utils import translation
+from django.utils.encoding import smart_text
+
+from fluent_pages.models.db import UrlNode
+
+
+class Command(NoArgsCommand):
+    help = "Print the MPTT tree structure for draft (or published) UrlNodes"
+    option_list = (
+        make_option(
+            '-p', '--published', action='store_true',
+            dest='print-published', default=False,
+            help="Print the tree for published copies only, not drafts"
+        ),
+    ) + NoArgsCommand.option_list
+
+    def print_item(self, item):
+        if hasattr(item, 'get_draft'):
+            published_status_list = ["draft=%d" % item.get_draft().pk]
+        else:
+            published_status_list = ["draft=%d" % item.pk]
+
+        if not hasattr(item, 'has_been_published'):
+            published_status_list.append("unpublishable")
+        elif not item.has_been_published:
+            published_status_list.append("unpublished")
+        else:
+            published_status_list.append(
+                "published=%d" % item.get_published().pk)
+
+        self.stdout.write(smart_text(
+            u"{level_indent}{item} [{url}]{publish_status}".format(
+                level_indent=" " * 4 * item._mpttfield('level'),
+                item=smart_text(repr(item)),
+                url=item._cached_url,
+                publish_status=" (%s)" % ', '.join(published_status_list),
+            )
+        ))
+
+    def print_mptt_tree(self, tree_roots):
+        seen_draft_pks = {}
+        for root in tree_roots:
+            self.print_item(root)
+            for item in root.get_descendants():
+                if root.is_draft:
+                    item_to_print = item.get_draft()
+                else:
+                    item_to_print = item.get_published()
+                    if not item_to_print:
+                        continue
+
+                # Avoid re-printing items we have already seen
+                draft_pk = item.get_draft().pk
+                if draft_pk in seen_draft_pks:
+                    continue
+                else:
+                    seen_draft_pks[draft_pk] = True
+
+                self.print_item(item_to_print)
+
+    def handle_noargs(self, **options):
+        draft_only = not options.get('print-published', False)
+        self.verbosity = options.get('verbosity', 1)
+
+        translation.activate('en')
+
+        # Find all UrlNode's without parents (root nodes) including only draft
+        # or published items, as requested
+        tree_roots_qs = UrlNode.objects.filter(
+            parent__isnull=True,
+            status=draft_only and UrlNode.DRAFT or UrlNode.PUBLISHED,
+        )
+        self.print_mptt_tree(tree_roots_qs)

--- a/icekit/management/commands/rebuild_page_tree.py
+++ b/icekit/management/commands/rebuild_page_tree.py
@@ -1,0 +1,160 @@
+from optparse import make_option
+
+from django.core.management.base import NoArgsCommand
+from django.utils.encoding import smart_text
+
+from fluent_pages import appsettings
+from fluent_pages.models.db import UrlNode_Translation, UrlNode
+
+
+class Command(NoArgsCommand):
+    """
+    Update the tree, rebuild the translated URL nodes.
+    """
+    help = "Update the cached_url for the translated URL node tree"
+    option_list = (
+        make_option(
+            '-n', '--dry-run', action='store_true', dest='dry-run', default=False,
+            help="Only list what will change, don't make the actual changes."
+        ),
+        make_option(
+            '-m', '--mptt-only', action='store_true', dest='mptt-only', default=False,
+            help="Only fix the MPTT fields, leave URLs unchanged."
+        ),
+    ) + NoArgsCommand.option_list
+
+    def handle_noargs(self, **options):
+        """
+        By default this function runs on all objects.
+
+        As we are using a publishing system it should only update draft
+        objects which can be modified in the tree structure.
+
+        Once published the tree preferences should remain the same to
+        ensure the tree data structure is consistent with what was
+        published by the user.
+        """
+        is_dry_run = options.get('dry-run', False)
+        mptt_only = options.get('mptt-only', False)
+        slugs = {}
+        overrides = {}
+
+        # MODIFIED
+        # This was modified to filter draft objects only.
+        # ORIGINAL LINE -> `parents = dict(UrlNode.objects.values_list('id', 'parent_id'))`
+        parents = dict(
+            UrlNode.objects.filter(status=UrlNode.DRAFT).values_list('id', 'parent_id')
+        )
+        # END MODIFIED
+
+        self.stdout.write("Updated MPTT columns")
+        if is_dry_run and mptt_only:
+            # Can't really do anything
+            return
+
+        if not is_dry_run:
+            # Fix MPTT first, that is the basis for walking through all nodes.
+
+            # MODIFIED
+            # Original line -> `UrlNode.objects.rebuild()`
+            # The `rebuild` function works on the manager. As we need to filter the queryset first
+            # it does not play nicely. The code for `rebuild` was brought in here and modified to
+            # work with the current context.
+
+            # Get opts from `UrlNode` rather than `self.model`.
+            opts = UrlNode._mptt_meta
+
+            # Add a queryset parameter will draft objects only.
+            qs = UrlNode.objects._mptt_filter(
+                qs=UrlNode.objects.filter(status=UrlNode.DRAFT),
+                parent=None
+            )
+            if opts.order_insertion_by:
+                qs = qs.order_by(*opts.order_insertion_by)
+            pks = qs.values_list('pk', flat=True)
+
+            # Obtain the `rebuild_helper` from `UrlNode.objects` rather than `self`.
+            rebuild_helper = UrlNode.objects._rebuild_helper
+            idx = 0
+            for pk in pks:
+                idx += 1
+                rebuild_helper(pk, 1, idx)
+            # END MODIFIED
+
+            self.stdout.write("Updated MPTT columns")
+            if mptt_only:
+                return
+
+            self.stdout.write("Updating cached URLs")
+            self.stdout.write("Page tree nodes:\n\n")
+
+        col_style = u"| {0:6} | {1:6} | {2:6} | {3}"
+        header = col_style.format("Site", "Page", "Locale", "URL")
+        sep = '-' * (len(header) + 40)
+        self.stdout.write(sep)
+        self.stdout.write(header)
+        self.stdout.write(sep)
+
+        # MODIFIED
+        # Modified to add the filter for draft objects only.
+        for translation in UrlNode_Translation.objects.filter(
+            master__status=UrlNode.DRAFT
+        ).select_related('master').order_by(
+            'master__parent_site__id', 'master__tree_id', 'master__lft', 'language_code'
+        ):
+            # END MODIFIED
+            slugs.setdefault(translation.language_code, {})[translation.master_id] = translation.slug
+            overrides.setdefault(translation.language_code, {})[translation.master_id] = translation.override_url
+
+            old_url = translation._cached_url
+            try:
+                new_url = self._construct_url(translation.language_code, translation.master_id, parents, slugs, overrides)
+            except KeyError:
+                if is_dry_run:
+                    # When the mptt tree is broken, some URLs can't be correctly generated yet.
+                    self.stderr.write("Failed to determine new URL for {0}, please run with --mptt-only first.".format(old_url))
+                    return
+                raise
+
+            if old_url != new_url:
+                translation._cached_url = new_url
+                if not is_dry_run:
+                    translation.save()
+
+            if old_url != new_url:
+                self.stdout.write(smart_text(u"{0}  {1} {2}\n".format(
+                    col_style.format(translation.master.parent_site_id, translation.master_id, translation.language_code, translation._cached_url),
+                    "WILL CHANGE from" if is_dry_run else "UPDATED from",
+                    old_url
+                )))
+            else:
+                self.stdout.write(smart_text(col_style.format(
+                    translation.master.parent_site_id, translation.master_id, translation.language_code, translation._cached_url
+                )))
+
+
+    def _construct_url(self, language_code, child_id, parents, slugs, overrides):
+        fallback = appsettings.FLUENT_PAGES_LANGUAGES.get_fallback_language(language_code)
+
+        breadcrumb = []
+        cur = child_id
+        while cur is not None:
+            breadcrumb.insert(0, cur)
+            cur = parents[cur]
+
+        url_parts = ['']
+        for id in breadcrumb:
+            try:
+                # Resets url_parts
+                override = overrides[language_code][id]
+                if override:
+                    url_parts = [override]
+                    continue
+            except KeyError:
+                pass
+            try:
+                url_parts.append(slugs[language_code][id])
+            except KeyError:
+                url_parts.append(slugs[fallback][id])
+
+        return (u'/'.join(url_parts) + u'/').replace('//', '/')

--- a/icekit/management/commands/resync_published_page_tree.py
+++ b/icekit/management/commands/resync_published_page_tree.py
@@ -1,0 +1,64 @@
+from optparse import make_option
+
+from django.core.management.base import NoArgsCommand
+from django.utils import translation
+from django.utils.encoding import smart_text
+
+from fluent_pages.models.db import UrlNode
+
+from icekit.publishing.models import \
+    sync_mptt_tree_fields_from_draft_to_published
+
+
+class Command(NoArgsCommand):
+    help = "Resync MPTT tree data and cached URLs for published page copies"
+    option_list = (
+        make_option(
+            '-n', '--dry-run', action='store_true', dest='dry-run',
+            default=False,
+            help="Only list what will change, don't make the actual changes."
+        ),
+        make_option(
+            '-f', '--force-update-cached-urls', action='store_true',
+            dest='force-update-cached-urls',
+            default=False,
+            help="Update cached URLs"
+        ),
+    ) + NoArgsCommand.option_list
+
+    def log(self, msg, at_verbosity=1):
+        if self.verbosity >= at_verbosity:
+            self.stdout.write(smart_text(msg))
+
+    def sync_draft_copy_tree_attrs_to_published_copy(
+            self, drafts_qs, is_dry_run=False, force_update_cached_urls=False):
+        for draft in drafts_qs:
+            published_copy = getattr(draft, 'publishing_linked', None)
+            if not published_copy:
+                continue
+            change_report = sync_mptt_tree_fields_from_draft_to_published(
+                draft,
+                dry_run=is_dry_run,
+                force_update_cached_urls=force_update_cached_urls)
+            if not change_report:
+                continue
+            for change in change_report:
+                item, description, old_value, new_value = change
+                if old_value != new_value:
+                    item_repr = smart_text(repr(item))
+                    self.log(u"%s %s => %s (was %s)" % (
+                        item_repr, description, new_value, old_value))
+
+    def handle_noargs(self, **options):
+        is_dry_run = options.get('dry-run', False)
+        force_update_cached_urls = options.get(
+            'force-update-cached-urls', False)
+        self.verbosity = options.get('verbosity', 1)
+
+        translation.activate('en')
+
+        drafts_qs = UrlNode.objects.filter(status=UrlNode.DRAFT)
+        self.sync_draft_copy_tree_attrs_to_published_copy(
+            drafts_qs,
+            is_dry_run=is_dry_run,
+            force_update_cached_urls=force_update_cached_urls)

--- a/icekit/publishing/models.py
+++ b/icekit/publishing/models.py
@@ -736,7 +736,8 @@ def sync_mptt_tree_fields_from_draft_to_published_post_save(
         sync_mptt_tree_fields_from_draft_to_published(instance)
 
 
-def sync_mptt_tree_fields_from_draft_to_published(draft_copy, dry_run=False):
+def sync_mptt_tree_fields_from_draft_to_published(
+        draft_copy, dry_run=False, force_update_cached_urls=False):
     """
     Sync tree structure changes from a draft publishable object to its
     published copy, and updates the published copy's Fluent cached URLs when
@@ -748,7 +749,7 @@ def sync_mptt_tree_fields_from_draft_to_published(draft_copy, dry_run=False):
     mptt_opts = getattr(draft_copy, '_mptt_meta', None)
     published_copy = getattr(draft_copy, 'publishing_linked', None)
     if not mptt_opts or not published_copy:
-        return
+        return {}
     # Identify changed values and prepare dict of changes to apply to DB
     parent_changed = draft_copy.parent != published_copy.parent
     update_kwargs = {
@@ -765,22 +766,26 @@ def sync_mptt_tree_fields_from_draft_to_published(draft_copy, dry_run=False):
         # Only parent may be None, never set tree_id/left/right/level to None
         and not (field != 'parent' and value is None)
     )
+
+    change_report = []
+    for field, new_value in update_kwargs.items():
+        old_value = getattr(published_copy, field)
+        change_report.append((draft_copy, field, old_value, new_value))
+
     # Forcibly update MPTT field values via UPDATE commands instead of normal
     # model attr changes, which MPTT ignores when you `save`
     if update_kwargs and not dry_run:
         type(published_copy).objects.filter(pk=published_copy.pk).update(
             **update_kwargs)
 
-    change_report = update_kwargs
-
     # If real tree structure (not just MPTT fields) has changed we must
     # regenerate the cached URLs for published copy translations.
-    if parent_changed:
+    if parent_changed or force_update_cached_urls:
         # Make our local published obj aware of DB change made by `update`
         published_copy.parent = draft_copy.parent
         # Regenerate the cached URLs for published copy translations.
-        change_report.update(
-            update_fluent_cached_urls(published_copy, dry_run=dry_run))
+        change_report += \
+            update_fluent_cached_urls(published_copy, dry_run=dry_run)
 
     return change_report
 
@@ -792,11 +797,13 @@ def update_fluent_cached_urls(item, dry_run=False):
     unnecessary and unwanted slug changes to ensure uniqueness, the logic for
     which doesn't work with our publishing.
     """
-    change_report = {}
+    change_report = []
     if hasattr(item, 'translations'):
         for translation in item.translations.all():
+            old_url = translation._cached_url
             item._update_cached_url(translation)
-            change_report['_cached_url'] = translation._cached_url
+            change_report.append(
+                (translation, '_cached_url', old_url, translation._cached_url))
             if not dry_run:
                 translation.save()
         if not dry_run:
@@ -812,8 +819,6 @@ def update_fluent_cached_urls(item, dry_run=False):
                         if child.is_published]
         for child in children:
             update_fluent_cached_urls(child, dry_run=dry_run)
-            change_report[u' child %s : _cached_url' % child] = \
-                child._cached_url
 
     return change_report
 


### PR DESCRIPTION
Add management commands to work with MPTT issues, adapted from the
SFMOMA project.

These commands are necessary because MPTT is still not working smoothly
with ICEkit due to unresolved issues in ICEkit Publishing and/or MPTT
itself.

  rebuild_page_tree

  A customised version of Fluent Page's command
  adjusted to ignore ICEkit's published copies of pages, and thereby
  avoid corrupting the MPTT tree instead of fixing it

  resync_published_page_tree

  Sync MPTT page tree hierarchy and Fluent's cached URL attributes from
  the draft page tree visible in the admin to corresponding published
  page copies, such that the published page tree hierarchy and URLs
  mirror the draft one (apart from URL slugs which may be different)

  print_mptt_tree`

  Print out the MPTT hierarchy, page IDs, and cached URLs for all draft
  or published pages for a human to check.