### PR TITLE
Fix Workflow app name to be 'icekit_workflow', re #190

### DIFF
--- a/icekit/workflow/__init__.py
+++ b/icekit/workflow/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = '%s.apps.AppConfig' % __name__

--- a/icekit/workflow/migrations/0001_initial.py
+++ b/icekit/workflow/migrations/0001_initial.py
@@ -22,5 +22,8 @@ class Migration(migrations.Migration):
                 ('assigned_to', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True, help_text=b'User responsible for item at this stage in the workflow')),
                 ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
             ],
+            options={
+                'db_table': 'workflow_workflowstate',
+            },
         ),
     ]

--- a/icekit/workflow/migrations/0002_auto_20161128_1105.py
+++ b/icekit/workflow/migrations/0002_auto_20161128_1105.py
@@ -9,7 +9,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('workflow', '0001_initial'),
+        ('icekit_workflow', '0001_initial'),
     ]
 
     operations = [

--- a/icekit/workflow/migrations/0003_auto_20161130_0741.py
+++ b/icekit/workflow/migrations/0003_auto_20161130_0741.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('workflow', '0002_auto_20161128_1105'),
+        ('icekit_workflow', '0002_auto_20161128_1105'),
     ]
 
     operations = [

--- a/icekit/workflow/migrations/0004_auto_20170130_1146.py
+++ b/icekit/workflow/migrations/0004_auto_20170130_1146.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('icekit_workflow', '0003_auto_20161130_0741'),
+    ]
+
+    operations = [
+        migrations.AlterModelTable(
+            name='workflowstate',
+            table=None,
+        ),
+        migrations.RunSQL(
+            "UPDATE django_content_type SET app_label='icekit_workflow' WHERE app_label='workflow';"
+        ),
+    ]

--- a/icekit/workflow/tests.py
+++ b/icekit/workflow/tests.py
@@ -163,7 +163,7 @@ class TestWorkflowMixinAdmin(WebTest):
                     args=(self.article.pk, )),
             user=self.superuser)
         self.assertEqual(200, response.status_code)
-        wfstate_prefix = 'workflow-workflowstate-content_type-object_id-0-'
+        wfstate_prefix = 'icekit_workflow-workflowstate-content_type-object_id-0-'
         # Check existing workflow status relationship with article
         form = response.forms[0]
         self.assertEqual(
@@ -266,7 +266,7 @@ class TestWorkflowAdminForPagesThatDoNotExtendOurAdminMixin(WebTest):
                     args=(self.layoutpage.pk, )),
             user=self.superuser)
         self.assertEqual(200, response.status_code)
-        wfstate_prefix = 'workflow-workflowstate-content_type-object_id-0-'
+        wfstate_prefix = 'icekit_workflow-workflowstate-content_type-object_id-0-'
         # Check existing workflow status relationship with layoutpage
         form = response.forms[0]
         self.assertEqual(


### PR DESCRIPTION
Add missing `default_app_config` setting to ensure Django uses our
AppConfig, thereby enforcing the 'icekit_workflow' name for the Workflow
app instead of just 'workflow'.

Since this is effectively an app rename, also updated the existing DB
migrations to use the new name and added a migration to rename the
app in Django's content types.

**WARNING:**

All existing projects that have used the ICEkit Workflow app must have
the following DB command run *before* further migrations are applied by
updated deployments etc:

    UPDATE django_migrations SET app='icekit_workflow' WHERE app='workflow'