### PR TITLE
Add `ContentListingPlugin`

### DIFF
--- a/icekit/plugins/content_listing/__init__.py
+++ b/icekit/plugins/content_listing/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = '%s.apps.AppConfig' % __name__

--- a/icekit/plugins/content_listing/abstract_models.py
+++ b/icekit/plugins/content_listing/abstract_models.py
@@ -30,7 +30,18 @@ class AbstractContentListingItem(ContentItem):
     def __str__(self):
         return 'Content Listing of %s' % self.content_type
 
-    def get_items(self):
+    def get_items(self, apply_limit=True):
+        """
+        Return the items to show in the listing.
+
+        If you override this method in a subclass but still call this method
+        via `super` be sure to pass ``apply_limit=False`` when calling the
+        method to avoid applying the count limit too early, then apply it
+        yourself at the end of the override method like this:
+
+            if self.limit:
+                qs = qs[:self.limit]
+        """
         model_class = self.content_type.model_class()
         if not model_class:
             return []
@@ -41,7 +52,7 @@ class AbstractContentListingItem(ContentItem):
                 items_qs = items_qs.draft()
             else:
                 items_qs = items_qs.published()
-        if self.limit:
+        if apply_limit and self.limit:
             items_qs = items_qs[:self.limit]
         # TODO Implement generally useful filters
         return items_qs

--- a/icekit/plugins/content_listing/abstract_models.py
+++ b/icekit/plugins/content_listing/abstract_models.py
@@ -1,0 +1,38 @@
+from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.translation import ugettext_lazy as _
+from django.contrib.contenttypes.models import ContentType
+
+from fluent_contents.models import ContentItem
+
+from icekit.publishing.middleware import is_draft_request_context
+
+
+@python_2_unicode_compatible
+class AbstractContentListingItem(ContentItem):
+    """
+    An embedded listing of arbitrary content items.
+    """
+    content_type = models.ForeignKey(
+        ContentType,
+        help_text="Content type of items to show in a listing",
+    )
+
+    class Meta:
+        abstract = True
+        verbose_name = _('Content Listing')
+
+    def __str__(self):
+        return 'Content Listing of %s' % self.content_type
+
+    def get_items(self):
+        ModelClass = self.content_type.model_class()
+        items_qs = ModelClass.objects.all()
+        # Filter by published status
+        if hasattr(items_qs, 'draft'):
+            if is_draft_request_context():
+                items_qs = items_qs.draft()
+            else:
+                items_qs = items_qs.published()
+        # TODO Implement generally useful filters
+        return items_qs

--- a/icekit/plugins/content_listing/abstract_models.py
+++ b/icekit/plugins/content_listing/abstract_models.py
@@ -22,6 +22,11 @@ class AbstractContentListingItem(ContentItem):
         help_text="How many items to show? No limit is applied if this"
                   " field is not set"
     )
+    no_items_message = models.CharField(
+        max_length=255,
+        blank=True, null=True,
+        help_text="Message to show if there are not items in listing.",
+    )
 
     class Meta:
         abstract = True

--- a/icekit/plugins/content_listing/apps.py
+++ b/icekit/plugins/content_listing/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class AppConfig(AppConfig):
+    name = '.'.join(__name__.split('.')[:-1])
+    label = "icekit_plugins_content_listing"
+    verbose_name = "Collected Content Listing"

--- a/icekit/plugins/content_listing/content_plugins.py
+++ b/icekit/plugins/content_listing/content_plugins.py
@@ -1,0 +1,17 @@
+"""
+Definition of the plugin.
+"""
+from django.utils.translation import ugettext_lazy as _
+
+from fluent_contents.extensions import ContentPlugin, plugin_pool
+
+from . import forms, models
+
+
+@plugin_pool.register
+class ContentListingPlugin(ContentPlugin):
+    model = models.ContentListingItem
+    category = _('Assets')
+    render_template = 'icekit/plugins/content_listing/default.html'
+    form = forms.ContentListingAdminForm
+    cache_output = False

--- a/icekit/plugins/content_listing/forms.py
+++ b/icekit/plugins/content_listing/forms.py
@@ -1,0 +1,25 @@
+from fluent_contents.forms import ContentItemForm
+
+#from icekit.content_collections.abstract_models import AbstractCollectedContent
+
+from .models import ContentListingItem
+
+
+class ContentListingAdminForm(ContentItemForm):
+
+    class Meta:
+        model = ContentListingItem
+        fields = '__all__'
+
+    # def __init__(self, *args, **kwargs):
+    #     super(ContentListingAdminForm, self).__init__(*args, **kwargs)
+    #     # TODO Restrict content types to those for models that are subclasses
+    #     # of `AbstractCollectedContent`?
+    #     valid_ct_ids = []
+    #     cts_qs = self.fields['content_type'].queryset.all()
+    #     for ct in cts_qs:
+    #         model = ct.model_class()
+    #         if model and issubclass(model, AbstractCollectedContent):
+    #             valid_ct_ids.append(ct.id)
+    #     cts_qs = self.fields['content_type'].queryset = \
+    #         cts_qs.filter(pk__in=valid_ct_ids)

--- a/icekit/plugins/content_listing/forms.py
+++ b/icekit/plugins/content_listing/forms.py
@@ -1,25 +1,45 @@
-from fluent_contents.forms import ContentItemForm
+from django.forms import ModelChoiceField
+from django.contrib.contenttypes.models import ContentType
 
-#from icekit.content_collections.abstract_models import AbstractCollectedContent
+from fluent_contents.forms import ContentItemForm
 
 from .models import ContentListingItem
 
 
+class ContentTypeModelChoiceField(ModelChoiceField):
+
+    def label_from_instance(self, content_type):
+        return u".".join(content_type.natural_key())
+
+
 class ContentListingAdminForm(ContentItemForm):
+
+    content_type = ContentTypeModelChoiceField(
+        queryset=ContentType.objects.all()
+    )
 
     class Meta:
         model = ContentListingItem
         fields = '__all__'
 
-    # def __init__(self, *args, **kwargs):
-    #     super(ContentListingAdminForm, self).__init__(*args, **kwargs)
-    #     # TODO Restrict content types to those for models that are subclasses
-    #     # of `AbstractCollectedContent`?
-    #     valid_ct_ids = []
-    #     cts_qs = self.fields['content_type'].queryset.all()
-    #     for ct in cts_qs:
-    #         model = ct.model_class()
-    #         if model and issubclass(model, AbstractCollectedContent):
-    #             valid_ct_ids.append(ct.id)
-    #     cts_qs = self.fields['content_type'].queryset = \
-    #         cts_qs.filter(pk__in=valid_ct_ids)
+    def __init__(self, *args, **kwargs):
+        super(ContentListingAdminForm, self).__init__(*args, **kwargs)
+        # Apply `filter_content_types` filter
+        self.fields['content_type'].queryset = self.filter_content_types(
+            self.fields['content_type'].queryset)
+
+    def filter_content_types(self, content_type_qs):
+        """
+        Filter the content types selectable for the content listing.
+
+        Example to restrict content types to those for models that are
+        subclasses of `AbstractCollectedContent`:
+
+            valid_ct_ids = []
+            for ct in content_type_qs:
+                model = ct.model_class()
+                if model and issubclass(model, AbstractCollectedContent):
+                    valid_ct_ids.append(ct.id)
+            return content_type_qs.filter(pk__in=valid_ct_ids)
+        """
+        return content_type_qs

--- a/icekit/plugins/content_listing/migrations/0001_initial.py
+++ b/icekit/plugins/content_listing/migrations/0001_initial.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('fluent_contents', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ContentListingItem',
+            fields=[
+                ('contentitem_ptr', models.OneToOneField(serialize=False, to='fluent_contents.ContentItem', parent_link=True, primary_key=True, auto_created=True)),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', help_text=b'Content type of items to show in a listing')),
+            ],
+            options={
+                'verbose_name': 'Content Listing',
+                'db_table': 'contentitem_icekit_plugins_content_listing_contentlistingitem',
+                'abstract': False,
+            },
+            bases=('fluent_contents.contentitem',),
+        ),
+    ]

--- a/icekit/plugins/content_listing/migrations/0002_contentlistingitem_limit.py
+++ b/icekit/plugins/content_listing/migrations/0002_contentlistingitem_limit.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('icekit_plugins_content_listing', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contentlistingitem',
+            name='limit',
+            field=models.IntegerField(help_text=b'How many items to show? No limit is applied if this field is not set', blank=True, null=True),
+        ),
+    ]

--- a/icekit/plugins/content_listing/migrations/0003_contentlistingitem_no_items_message.py
+++ b/icekit/plugins/content_listing/migrations/0003_contentlistingitem_no_items_message.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('icekit_plugins_content_listing', '0002_contentlistingitem_limit'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contentlistingitem',
+            name='no_items_message',
+            field=models.CharField(help_text=b'Message to show if there are not items in listing.', max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/icekit/plugins/content_listing/models.py
+++ b/icekit/plugins/content_listing/models.py
@@ -1,0 +1,8 @@
+from . import abstract_models
+
+
+class ContentListingItem(abstract_models.AbstractContentListingItem):
+    """
+    An embedded listing of arbitrary content items.
+    """
+    pass

--- a/icekit/plugins/content_listing/templates/icekit/plugins/content_listing/_item.html
+++ b/icekit/plugins/content_listing/templates/icekit/plugins/content_listing/_item.html
@@ -1,0 +1,4 @@
+<li><a href="{{ item.get_absolute_url }}">
+	{{ item.title|safe }}
+</a></li>
+

--- a/icekit/plugins/content_listing/templates/icekit/plugins/content_listing/default.html
+++ b/icekit/plugins/content_listing/templates/icekit/plugins/content_listing/default.html
@@ -2,8 +2,7 @@
 	{% for item in instance.get_items %}
 		{% include "icekit/plugins/content_listing/_item.html" %}
 	{% empty %}
-			<li>There are no items to show on this page</li>
-		{{ instance.get_default_embed }}
+		<li>{{ instance.no_items_message|default:"There are no items to show" }}</li>
 	{% endfor %}
 </div>
 

--- a/icekit/plugins/content_listing/templates/icekit/plugins/content_listing/default.html
+++ b/icekit/plugins/content_listing/templates/icekit/plugins/content_listing/default.html
@@ -1,0 +1,9 @@
+<div class="content-listing">
+	{% for item in instance.get_items %}
+		{% include "icekit/plugins/content_listing/_item.html" %}
+	{% empty %}
+			<li>There are no items to show on this page</li>
+		{{ instance.get_default_embed }}
+	{% endfor %}
+</div>
+

--- a/icekit/project/settings/_base.py
+++ b/icekit/project/settings/_base.py
@@ -505,6 +505,7 @@ ASSETS_PLUGINS = [
     'FilePlugin',
     'SharedContentPlugin',
     'ContactPersonPlugin',
+    'ContentListingPlugin',
 ]
 
 EMBED_PLUGINS = [
@@ -705,6 +706,7 @@ INSTALLED_APPS += (
     # 'icekit.plugins.brightcove',
     'icekit.plugins.child_pages',
     'icekit.plugins.contact_person',
+    'icekit.plugins.content_listing',
     'icekit.plugins.faq',
     'icekit.plugins.file',
     'icekit.plugins.horizontal_rule',

--- a/icekit/project/settings/glamkit.py
+++ b/icekit/project/settings/glamkit.py
@@ -8,6 +8,7 @@ INSTALLED_APPS += (
 
     'icekit_events',
     'icekit_events.event_types.simple',
+    'icekit_events.plugins.event_content_listing',
     'icekit_events.plugins.links',
     'icekit_events.plugins.todays_occurrences',
     'icekit_events.page_types.eventlistingfordate',
@@ -54,7 +55,8 @@ LINK_PLUGINS += [
     'TodaysOccurrencesPlugin',
 ]
 
-DEFAULT_PLUGINS += SPONSOR_PLUGINS + LINK_PLUGINS
+DEFAULT_PLUGINS += \
+    SPONSOR_PLUGINS + LINK_PLUGINS + ['EventContentListingPlugin']
 
 
 # CONFIGURE PLACEHOLDERS ######################################################


### PR DESCRIPTION
Add a new `ContentListingPlugin` that allows CMS admins to add listings of arbitrary items to pages as content blocks. The implementation is very generic with minimal controls – just model content type to list, an optional count limit, and a message to display if there are no items to list.

This plugin is mainly intended to be used as a base for more focused, richer content listing plugins such as the new [`EventContentListingPlugin`in ICEkit Events](https://github.com/ic-labs/icekit-events/pull/29).