### PR TITLE
Add support for IIIF Image API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
 RUN echo 'deb https://dl.bintray.com/sobolevn/deb git-secret main' | tee -a /etc/apt/sources.list
 RUN wget -nv -O - https://api.bintray.com/users/sobolevn/keys/gpg/public.key | apt-key add -
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get install --yes --force-yes --no-install-recommends \
         git-secret \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 In development
 --------------
 
+-  Added implementation of key parts of IIIF 2.1 spec for privileged users.
+
 -  Fleshed out Image model with more metadata and fields for rights/usage.
 
 -  Add ``icekit.workflow`` application to associate, manage, and filter

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 In development
 --------------
 
+-  Fleshed out Image model with more metadata and fields for rights/usage.
+
 -  Add ``icekit.workflow`` application to associate, manage, and filter
    workflow state information like status and user-assigment for
    arbitrary models.

--- a/docs/topics/iiif.rst
+++ b/docs/topics/iiif.rst
@@ -1,0 +1,87 @@
+International Image Interoperability Framework (IIIF)
+=====================================================
+
+Access to image-based resources is fundamental to research, scholarship and
+the transmission of cultural knowledge. Digital images are a container for
+much of the information content in the Web-based delivery of images, books,
+newspapers, manuscripts, maps, scrolls, single sheet collections, and archival
+ materials. Yet much of the Internet’s image-based resources are locked up in
+ silos, with access restricted to bespoke, locally built applications.
+
+A growing community of the world’s leading research libraries and image
+repositories have embarked on an effort to collaboratively produce an
+interoperable technology and community framework for image delivery.
+
+IIIF (International Image Interoperability Framework) has the following goals:
+
+-  To give scholars an unprecedented level of uniform and rich access to
+   image-based resources hosted around the world.
+-  To define a set of common application programming interfaces that support
+   interoperability between image repositories.
+-  To develop, cultivate and document shared technologies, such as image
+   servers and web clients, that provide a world-class user experience in
+   viewing, comparing, manipulating and annotating images.
+
+Usage
+-----
+
+GLAMkit contains a basic implementation key parts of the
+`IIIF 2.1 spec <http://iiif.io/api/image/2.1/>`_.
+ allows privileged users (with ``can_use_iiif_image_api`` permission) to
+ repurpose images using URL paths like::
+
+   # original size as png file
+   /iiif/{ID}/full/max/0/default.png
+
+   # cropped to a square
+   /iiif/{ID}/square/max/0/default.jpg
+
+   # resize to 400px wide
+   /iiif/{ID}/full/400,/0/default.jpg
+
+   # resize to fit in 400x300, tif file
+   /iiif/{ID}/full/!400,300/0/default.tif
+
+   # crop to 400x300,
+   /iiif/{ID}/full/!400,300/0/default.jpg
+
+   # crop from 100,150 a region of 900x600 px, and resize to 300px wide.
+   /iiif/{ID}/100,150,900,600/300,/0/default.png
+
+   # metadata
+   /iiif/{ID}/info.json
+
+where ``{ID}`` is the ID of an image in the ``Image`` model.
+
+The resulting image is created and stored permanently the first time it is
+requested.
+
+Notes
+-----
+
+-  The feature was inspired by
+   `Aaron Straup Cope <http://www.aaronland.info/weblog/2017/03/05/record/#numbers>`_
+   and `Micah Walter <https://labs.cooperhewitt.org/2017/parting-gifts/>`_ working at
+   the Cooper-Hewitt Labs, but we're less far along the path of asynchronous
+   generation and efficient serving.
+
+-  Because GLAMkit currently generates files synchronously and stores them
+   permanently, and serves them via a proxy, the IIIF solution is not suitable
+   for serving requests created by the general public. As such, we've limited
+   usage to Users with the ``can_use_iiif_image_api`` permission. In future,
+   we may allow public to read images, but only privileged users to create them,
+   and/or we may introduce rate-limiting and image expiry of generated images
+   for certain classes of users. That opens the way to using IIIF images
+   throughout the GLAMkit front-end.
+
+-  Image rotations other than 0 degrees aren't currently supported. Note that
+   it should be possible to losslessly rotate jpgs by multiples of 90 degrees.
+
+-  The resulting images have the color profile stripped for smaller file size,
+   and there is no particular colorspace conversion before doing so.
+   Implementers may wish to use the code in glamkit-imagetools for ensuring
+   sRGB conversion either at upload time or at resize time.
+
+-  The Django instance reads and serves the images from storage every time.
+   Ideally the image would be statically served direct from the storage, and
+   Django would redirect there.

--- a/icekit/fields.py
+++ b/icekit/fields.py
@@ -3,13 +3,12 @@ import logging
 from any_urlfield.forms import SimpleRawIdWidget
 from any_urlfield.models import AnyUrlField
 from any_urlfield.registry import UrlTypeRegistry
-from django import forms
 from django.conf import settings
 from django.db import models
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 from fluent_pages.models import Page
-from icekit.validators import RelativeURLValidator
+from django.db.models import ImageField
 
 from . import validators
 
@@ -62,6 +61,18 @@ class ICEkitURLField(AnyUrlField):
                         .format(cls, ModelClass))
         else:
             cls.register_model.register(ModelClass, **kwargs)
+
+
+class QuietImageField(ImageField):
+    """An imagefield that doesn't lose the plot when trying to find the
+    dimensions of an image that doesn't exist"""
+
+    def update_dimension_fields(self, *args, **kwargs):
+        try:
+            super(QuietImageField, self).update_dimension_fields(
+                *args, **kwargs)
+        except IOError:
+            pass
 
 
 # (Re-)Register Fluent's Page model in our fresh subclass,

--- a/icekit/plugins/iiif/__init__.py
+++ b/icekit/plugins/iiif/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = '%s.apps.AppConfig' % __name__

--- a/icekit/plugins/iiif/apps.py
+++ b/icekit/plugins/iiif/apps.py
@@ -1,7 +1,22 @@
 from django.apps import AppConfig
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 
 
 class AppConfig(AppConfig):
     name = '.'.join(__name__.split('.')[:-1])
     label = 'icekit_plugins_iiif'
     verbose_name = "IIIF Basics"
+
+    def ready(self):
+        # Create custom permission pointing to User, because we have no other
+        # model to hang it off for now...
+        # TODO This is a hack, find a better way
+        User = get_user_model()
+        content_type = ContentType.objects.get_for_model(User)
+        Permission.objects.get_or_create(
+            codename='can_use_iiif_image_api',
+            name='Can Use IIIF Image API',
+            content_type=content_type,
+        )

--- a/icekit/plugins/iiif/apps.py
+++ b/icekit/plugins/iiif/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class AppConfig(AppConfig):
+    name = '.'.join(__name__.split('.')[:-1])
+    label = 'icekit_plugins_iiif'
+    verbose_name = "IIIF Basics"

--- a/icekit/plugins/iiif/tests.py
+++ b/icekit/plugins/iiif/tests.py
@@ -1,0 +1,334 @@
+from mock import patch, Mock
+
+from django.apps import apps
+from django.core.urlresolvers import reverse
+from django.http import HttpResponse
+from django.test import TestCase
+
+from django_webtest import WebTest
+from django_dynamic_fixture import G
+
+from .utils import IIIFImageApiException, parse_dimensions_string, \
+    parse_region, parse_size
+
+
+Image = apps.get_model('icekit_plugins_image.Image')
+
+
+class TestImageApiUtils(TestCase):
+
+    def test_parse_dimensions_string(self):
+        self.assertEqual(
+            (0, 0, 1, 1), parse_dimensions_string('0,0,1,1'))
+        self.assertEqual(
+            (0.1, 0.1, 0.1, 0.1),
+            parse_dimensions_string('0.1,0.1,0.1,0.1', permit_floats=True))
+        # Must use `permit_floats=True` for float values
+        self.assertRaises(
+            IIIFImageApiException,
+            parse_dimensions_string,
+            '0.1,0,1,1')
+        # Wrong number of elements
+        self.assertRaises(
+            IIIFImageApiException,
+            parse_dimensions_string,
+            '0,1,1')
+        self.assertRaises(
+            IIIFImageApiException,
+            parse_dimensions_string,
+            '0,0,0,1,1')
+        # Negative numbers not permitted
+        self.assertRaises(
+            IIIFImageApiException,
+            parse_dimensions_string,
+            '-1,0,1,1')
+        # Elements must be numerical
+        self.assertRaises(
+            IIIFImageApiException,
+            parse_dimensions_string,
+            'a,0,1,1')
+
+    def test_parse_region(self):
+        # Region: full
+        self.assertEqual(
+            (0, 0, 300, 200),
+            parse_region('full', 300, 200))
+        # Region: square
+        self.assertEqual(
+            (50, 0, 200, 200),
+            parse_region('square', 300, 200))
+        self.assertEqual(
+            (0, 25, 200, 200),
+            parse_region('square', 200, 250))
+        # Region: x,y,width,height pixels
+        self.assertEqual(
+            (0, 25, 100, 200),
+            parse_region('0,25,100,200', 200, 250))
+        self.assertEqual(
+            (0, 25, 200, 175),  # Don't extend crop beyond image height
+            parse_region('0,25,200,200', 200, 200))
+        self.assertEqual(
+            (100, 0, 100, 200),  # Don't extend crop beyond image width
+            parse_region('100,0,200,200', 200, 250))
+        # Region: x,y,width,height percentages
+        self.assertEqual(
+            (50, 25, 375, 100),
+            parse_region('pct:10,12.5,75,50', 500, 200))
+        self.assertEqual(
+            (375, 0, 125, 100),  # Don't extend crop beyond image width
+            parse_region('pct:75,0,50,50', 500, 200))
+        self.assertEqual(
+            (0, 0, 500, 200),  # Don't extend crop beyond image height
+            parse_region('pct:0,0,100,200', 500, 200))
+
+    def test_parse_size(self):
+        # Size: full/max
+        self.assertEqual(
+            (100, 200), parse_size('full', 100, 200))
+        self.assertEqual(
+            (200, 100), parse_size('max', 200, 100))
+        # Size: pct
+        self.assertEqual(
+            (100, 200), parse_size('pct:100', 100, 200))
+        self.assertEqual(
+            (50, 100), parse_size('pct:50', 100, 200))
+        # Size: w,h
+        self.assertEqual(
+            (25, 75), parse_size('25,75', 100, 200))
+        # Size: w, (maintain aspect ratio)
+        self.assertEqual(
+            (50, 100), parse_size('50,', 100, 200))
+        self.assertEqual(
+            # Can scale beyond original image size
+            (125, 250), parse_size('125,', 100, 200))
+        # Size: ,h (maintain aspect ratio)
+        self.assertEqual(
+            (50, 100), parse_size(',100', 100, 200))
+        self.assertEqual(
+            # Can scale beyond original image size
+            (125, 250), parse_size(',250', 100, 200))
+        # Size: !w,h (best-fit)
+        self.assertEqual(
+            # Width is best fit
+            (80, 160), parse_size('!80,100', 100, 200))
+        self.assertEqual(
+            # Width is best fit
+            (80, 160), parse_size('!80,160', 100, 200))
+        self.assertEqual(
+            # Height is best fit
+            (75, 150), parse_size('!25,150', 100, 200))
+        self.assertEqual(
+            # Height is best fit, can scale beyond original image size
+            (250, 250), parse_size('!100,250', 200, 200))
+
+
+class TestImageAPIViews(WebTest):
+
+    def setUp(self):
+        self.image = G(
+            Image,
+            width=200,
+            height=300,
+        )
+        # Set up mocks used by default
+        patcher = patch(
+            'icekit.plugins.iiif.views.FileResponse')
+        self.FileResponse = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch(
+            'icekit.plugins.iiif.views.get_thumbnailer')
+        self.get_thumbnailer = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch(
+            'icekit.plugins.iiif.views.open', return_value='open_mocked')
+        self.open = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.thumbnailer = Mock()
+        self.get_thumbnailer.return_value = self.thumbnailer
+
+        self.FileResponse.return_value = HttpResponse('mocked')
+
+    def test_iff_image_api_info(self):
+        path = reverse('iiif_image_api_info', args=[self.image.pk])
+        response = self.app.get(path)
+        expected = {
+            "@context": "http://iiif.io/api/image/2/context.json",
+            "@id": path,
+            "protocol": "http://iiif.io/api/image",
+            "width": self.image.width,
+            "height": self.image.height,
+        }
+        self.assertEqual(expected, response.json)
+
+    def test_iiif_image_api_basics(self):
+        # Invalid image identifier
+        response = self.app.get(
+            reverse('iiif_image_api',
+                    args=[0, 'full', 'max', '0', 'default', 'jpg']),
+            expect_errors=True,
+        )
+        self.assertEqual(404, response.status_code)
+        # Correct use
+        response = self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', 'max', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (self.image.width, self.image.height),
+        })
+        self.FileResponse.assert_called_with(
+                'open_mocked', content_type='image/jpg')
+
+    def test_iiif_image_api_region(self):
+        # Region: full
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', 'max', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (self.image.width, self.image.height),
+        })
+        # Region: square, 200 x 300 image
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'square', 'max', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 50),  # NOTE: Auto-cropped to center square in image
+            'size': (self.image.width, self.image.width),  # NOTE: width is smallest edge
+        })
+        # Region: x,y,w,h
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, '20,30,50,90', 'max', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (20, 30),
+            'size': (50, 90),
+        })
+        # Region: x,y,w,h (crop isn't permitted to exceed original image)
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, '100,50,150,300', 'max', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (100, 50),
+            'size': (100, 250),  # Width & height reduced to fit bounds
+        })
+        # Region: pct:x,y,w,h
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'pct:10,50,75,50', 'max', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (20, 150),
+            'size': (150, 150),  # Width & height reduced to fit bounds
+        })
+
+    def test_iiif_image_api_size(self):
+        # Size: max
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', 'max', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (self.image.width, self.image.height),
+        })
+        # Size: full
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', 'full', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (self.image.width, self.image.height),
+        })
+        # Size: pct
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', 'pct:50', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (self.image.width / 2, self.image.height / 2),
+        })
+        # Size: w,h
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', '100,150', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (100, 150),
+        })
+        # Size: w, (maintain aspect ratio)
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', '150,', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (150, 225),
+        })
+        # Size: ,h (maintain aspect ratio, scale beyond original image size)
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', ',600', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (400, 600),
+        })
+        # Size: !w,h (best-fit)
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', '!150,200', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (150, 225),  # Width is best fit
+        })
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', '!300,240', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (160, 240),  # Height is best fit
+        })
+
+    def test_iiif_image_api_quality(self):
+        # Quality: default
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', 'max', '0', 'default', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (self.image.width, self.image.height),
+        })
+        # Quality: color
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', 'max', '0', 'color', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (self.image.width, self.image.height),
+        })
+        # Quality: gray
+        self.app.get(
+            reverse('iiif_image_api',
+                    args=[self.image.pk, 'full', 'max', '0', 'gray', 'jpg']),
+        )
+        self.thumbnailer.get_thumbnail.assert_called_with({
+            'crop': (0, 0),
+            'size': (self.image.width, self.image.height),
+            'bw': True,  # NOTE: Black-and-white filter added
+        })

--- a/icekit/plugins/iiif/tests.py
+++ b/icekit/plugins/iiif/tests.py
@@ -113,16 +113,16 @@ class TestImageApiUtils(TestCase):
         # Size: !w,h (best-fit)
         self.assertEqual(
             # Width is best fit
-            (80, 160), parse_size('!80,100', 100, 200))
+            (80, 160), parse_size('!80,200', 100, 200))
         self.assertEqual(
             # Width is best fit
             (80, 160), parse_size('!80,160', 100, 200))
         self.assertEqual(
             # Height is best fit
-            (75, 150), parse_size('!25,150', 100, 200))
+            (75, 150), parse_size('!80,150', 100, 200))
         self.assertEqual(
             # Height is best fit, can scale beyond original image size
-            (250, 250), parse_size('!100,250', 200, 200))
+            (250, 250), parse_size('!400,250', 200, 200))
 
 
 class TestImageAPIViews(WebTest):
@@ -331,7 +331,7 @@ class TestImageAPIViews(WebTest):
         # Size: !w,h (best-fit)
         self.app.get(
             reverse('iiif_image_api',
-                    args=[self.image.pk, 'full', '!150,200', '0', 'default', 'jpg']),
+                    args=[self.image.pk, 'full', '!150,250', '0', 'default', 'jpg']),
             user=self.superuser,
         )
         self.thumbnailer.get_thumbnail.assert_called_with({

--- a/icekit/plugins/iiif/tests.py
+++ b/icekit/plugins/iiif/tests.py
@@ -152,11 +152,6 @@ class TestImageAPIViews(WebTest):
         self.get_thumbnailer = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch(
-            'icekit.plugins.iiif.views.open', return_value='open_mocked')
-        self.open = patcher.start()
-        self.addCleanup(patcher.stop)
-
         self.thumbnailer = Mock()
         self.get_thumbnailer.return_value = self.thumbnailer
 
@@ -237,6 +232,9 @@ class TestImageAPIViews(WebTest):
         self.assertEqual(404, response.status_code)
 
         # Correct use
+        thumbnail = Mock()
+        self.thumbnailer.get_thumbnail.return_value = thumbnail
+        thumbnail.read.return_value = 'read_mocked'
         response = self.app.get(
             reverse(
                 'iiif_image_api',
@@ -248,7 +246,7 @@ class TestImageAPIViews(WebTest):
             'size': (self.image.width, self.image.height),
         })
         self.FileResponse.assert_called_with(
-                'open_mocked', content_type='image/jpg')
+            'read_mocked', content_type='image/jpg')
 
     def test_iiif_image_api_region(self):
         # Region: full

--- a/icekit/plugins/iiif/urls.py
+++ b/icekit/plugins/iiif/urls.py
@@ -5,13 +5,14 @@ from .views import iiif_image_api_info, iiif_image_api
 urlpatterns = patterns(
     '',
     url(
-        r'(?P<identifier>.+)/info.json',
+        r'(?P<identifier_param>.+)/info.json',
         iiif_image_api_info,
         name='iiif_image_api_info',
     ),
     url(
-        r'(?P<identifier>[^/]+)/(?P<region>[^/]+)/(?P<size>[^/]+)'
-        r'/(?P<rotation>[^/]+)/(?P<quality>[^.]+).(?P<output_format>.+)',
+        r'(?P<identifier_param>[^/]+)/(?P<region_param>[^/]+)'
+        r'/(?P<size_param>[^/]+)/(?P<rotation_param>[^/]+)'
+        r'/(?P<quality_param>[^.]+).(?P<format_param>.+)',
         iiif_image_api,
         name='iiif_image_api',
     ),

--- a/icekit/plugins/iiif/urls.py
+++ b/icekit/plugins/iiif/urls.py
@@ -10,8 +10,8 @@ urlpatterns = patterns(
         name='iiif_image_api_info',
     ),
     url(
-        r'(?P<identifier>.+)/(?P<region>.+)/(?P<size>.+)/(?P<rotation>.+)'
-        r'(?P<quality>.+)/(?P<format>.+)',
+        r'(?P<identifier>[^/]+)/(?P<region>[^/]+)/(?P<size>[^/]+)'
+        r'/(?P<rotation>[^/]+)/(?P<quality>[^.]+).(?P<output_format>.+)',
         iiif_image_api,
         name='iiif_image_api',
     ),

--- a/icekit/plugins/iiif/urls.py
+++ b/icekit/plugins/iiif/urls.py
@@ -1,0 +1,18 @@
+from django.conf.urls import include, patterns, url
+
+from .views import iiif_image_api_info, iiif_image_api
+
+urlpatterns = patterns(
+    '',
+    url(
+        r'(?P<identifier>.+)/info.json',
+        iiif_image_api_info,
+        name='iiif_image_api_info',
+    ),
+    url(
+        r'(?P<identifier>.+)/(?P<region>.+)/(?P<size>.+)/(?P<rotation>.+)'
+        r'(?P<quality>.+)/(?P<format>.+)',
+        iiif_image_api,
+        name='iiif_image_api',
+    ),
+)

--- a/icekit/plugins/iiif/utils.py
+++ b/icekit/plugins/iiif/utils.py
@@ -106,6 +106,7 @@ def parse_region(region, image_width, image_height):
 
 
 def parse_size(size, image_width, image_height):
+    aspect_ratio = float(image_width) / image_height
     if size in ('full', 'max'):
         width, height = image_width, image_height
     elif size.startswith('pct:'):
@@ -116,18 +117,14 @@ def parse_size(size, image_width, image_height):
     elif size.startswith('!'):
         # Best fit
         width, height = parse_width_height_string(size[1:])
-        # TODO This best-fit test algorithm is probably too naive
-        if abs(image_width - width) <= abs(image_height - height):
-            scale = float(width) / image_width
+        if width / aspect_ratio <= height:
             # Requested width is best-fit
-            height = image_height * scale
+            height = int(width / aspect_ratio)
         else:
             # Requested height is best-fit
-            scale = float(height) / image_height
-            width = image_width * scale
+            width = int(height * aspect_ratio)
     else:
         width, height = parse_width_height_string(size)
-        aspect_ratio = float(image_width) / image_height
         # Handle "w,"
         if height is None:
             height = width / aspect_ratio

--- a/icekit/plugins/iiif/utils.py
+++ b/icekit/plugins/iiif/utils.py
@@ -169,10 +169,16 @@ def parse_quality(quality):
     return quality
 
 
-def parse_format(output_format):
-    valid = ('jpg',)
-    if output_format not in valid:
+def parse_format(output_format, image_format):
+    # TODO Do we need to limit output format based on image's existing format?
+    supported = ('jpg', 'tif', 'png', 'gif')
+    unsupported = ('jp2', 'pdf', 'webp')
+    if output_format in unsupported:
         raise UnsupportedError(
-            "Image API format parameters other than %r"
-            " are not yet supported: %s" % (valid, output_format))
+            "Image API format parameters %r are not yet supported: %s"
+            % (unsupported, output_format))
+    if output_format not in supported:
+        raise ClientError(
+            "Invalid Image API format parameter not in %r: %s"
+            % (supported + unsupported, output_format))
     return output_format

--- a/icekit/plugins/iiif/utils.py
+++ b/icekit/plugins/iiif/utils.py
@@ -1,0 +1,170 @@
+class IIIFImageApiException(Exception):
+    pass
+
+
+def parse_dimensions_string(dimension_string, permit_floats=False):
+    # Split dimensions string into sections
+    try:
+        x, y, width, height = dimension_string.split(',')
+    except ValueError, ex:
+        raise IIIFImageApiException(
+            "Cannot split dimensions string %s: %s" % (dimension_string, ex))
+    # Parse dimensions string sections into numerical values
+    try:
+        if permit_floats:
+            x = float(x)
+            y = float(y)
+            width = float(width)
+            height = float(height)
+        else:
+            x = int(x)
+            y = int(y)
+            width = int(width)
+            height = int(height)
+    except ValueError, ex:
+        raise IIIFImageApiException(
+            "Cannot parse numbers from dimensions string %s: %s"
+            % (dimension_string, ex))
+    # Sanity-checks for numerical values
+    # Negatives not permitted
+    if x < 0 or y < 0 or width < 0 or height < 0:
+        raise IIIFImageApiException(
+            "Negative numbers illegal in dimensions string %s"
+            % dimension_string)
+    # Zero width or height not permitted
+    if width <= 0 or height <= 0:
+        raise IIIFImageApiException(
+            "Zero numbers illegal in dimensions string %s"
+            % dimension_string)
+    return (x, y, width, height)
+
+
+def parse_width_height_string(wh_string):
+    # Split dimensions string into sections
+    try:
+        width, height = wh_string.split(',')
+    except ValueError, ex:
+        raise IIIFImageApiException(
+            "Cannot split width-height string %s: %s" % (wh_string, ex))
+    # Parse width-height string sections into numerical values
+    try:
+        width = int(width) if width else None
+        height = int(height) if height else None
+    except ValueError, ex:
+        raise IIIFImageApiException(
+            "Cannot parse numbers from width-height string %s: %s"
+            % (wh_string, ex))
+    # Sanity-checks for numerical values
+    # At least one of width or height must be set
+    if width is None and height is None:
+        raise IIIFImageApiException(
+            "There must be a value in width-height string %s"
+            % wh_string)
+    # Negatives not permitted
+    if (width is not None and width <= 0) or \
+            (height is not None and height <= 0):
+        raise IIIFImageApiException(
+            "Zero or negative numbers illegal in width-height string %s"
+            % wh_string)
+    return (width, height)
+
+
+def parse_region(region, image_width, image_height):
+    """
+    Parse Region parameter to determine the rectangular portion of the full
+    image to be returned, informed by the actual image dimensions.
+    Returns (x, y, width, height):
+        - x,y are pixel offsets into the image from the upper left
+        - width, height are pixel dimensions for cropped image.
+    """
+    if region == 'full':
+        # Return complete image, no cropping
+        x, y, width, height = 0, 0, image_width, image_height
+    elif region == 'square':
+        square_size = min(image_width, image_height)
+        # Generate x,y offsets to centre cropped image. This is not mandated
+        # by the spec but is recommended as a sensible default.
+        x = int((image_width - square_size) / 2)
+        y = int((image_height - square_size) / 2)
+        width = height = square_size
+    elif region.startswith('pct:'):
+        x_pct, y_pct, width_pct, height_pct = \
+            parse_dimensions_string(region[4:], permit_floats=True)
+        x, y, width, height = map(int, (
+            x_pct / 100 * image_width,
+            y_pct / 100 * image_height,
+            width_pct / 100 * image_width,
+            height_pct / 100 * image_height,
+        ))
+    else:
+        x, y, width, height = parse_dimensions_string(region)
+    # If region extends beyond original's dimensions, crop extends only to
+    # image edge.
+    width = min(width, image_width - x)
+    height = min(height, image_height - y)
+    return x, y, width, height
+
+
+def parse_size(size, image_width, image_height):
+    if size in ('full', 'max'):
+        width, height = image_width, image_height
+    elif size.startswith('pct:'):
+        # Percentage applied to width and height
+        pct = float(size[4:])
+        width = pct / 100 * image_width
+        height = pct / 100 * image_height
+    elif size.startswith('!'):
+        # Best fit
+        width, height = parse_width_height_string(size[1:])
+        # TODO This best-fit test algorithm is probably too naive
+        if abs(image_width - width) <= abs(image_height - height):
+            scale = float(width) / image_width
+            # Requested width is best-fit
+            height = image_height * scale
+        else:
+            # Requested height is best-fit
+            scale = float(height) / image_height
+            width = image_width * scale
+    else:
+        width, height = parse_width_height_string(size)
+        aspect_ratio = float(image_width) / image_height
+        # Handle "w,"
+        if height is None:
+            height = width / aspect_ratio
+        # Handle ",h"
+        elif width is None:
+            width = height * aspect_ratio
+    return width, height
+
+
+def parse_rotation(rotation_str, image_width, image_height):
+    try:
+        rotation = int(rotation_str)
+    except ValueError, ex:
+        raise IIIFImageApiException(
+            "Cannot parse number from rotation string %s: %s"
+            % (rotation_str, ex))
+    valid = (0, 360)
+    if rotation not in valid:
+        raise IIIFImageApiException(
+            "Image API rotation parameters other than %r"
+            " are not yet supported %s" % (valid, rotation))
+    return rotation
+
+
+def parse_quality(quality):
+    valid = ('default', 'color', 'gray',)
+    if quality not in valid:
+        raise IIIFImageApiException(
+            "Image API quality parameters other than %r"
+            " are not yet supported %s" % (valid, quality))
+    return quality
+
+
+def parse_format(output_format):
+    valid = ('jpg',)
+    if output_format not in valid:
+        raise IIIFImageApiException(
+            "Image API format parameters other than %r"
+            " are not yet supported %s" % (valid, output_format))
+    return output_format

--- a/icekit/plugins/iiif/utils.py
+++ b/icekit/plugins/iiif/utils.py
@@ -1,4 +1,15 @@
 class IIIFImageApiException(Exception):
+    """ Base class for IIIF Image API Exceptions """
+    pass
+
+
+class ClientError(IIIFImageApiException):
+    """ Invalid IIIF Image API operation requested by client """
+    pass
+
+
+class UnsupportedError(IIIFImageApiException):
+    """ Unsupported IIIF Image API operation requested by client """
     pass
 
 
@@ -7,7 +18,7 @@ def parse_dimensions_string(dimension_string, permit_floats=False):
     try:
         x, y, width, height = dimension_string.split(',')
     except ValueError, ex:
-        raise IIIFImageApiException(
+        raise ClientError(
             "Cannot split dimensions string %s: %s" % (dimension_string, ex))
     # Parse dimensions string sections into numerical values
     try:
@@ -22,18 +33,18 @@ def parse_dimensions_string(dimension_string, permit_floats=False):
             width = int(width)
             height = int(height)
     except ValueError, ex:
-        raise IIIFImageApiException(
+        raise ClientError(
             "Cannot parse numbers from dimensions string %s: %s"
             % (dimension_string, ex))
     # Sanity-checks for numerical values
     # Negatives not permitted
     if x < 0 or y < 0 or width < 0 or height < 0:
-        raise IIIFImageApiException(
+        raise ClientError(
             "Negative numbers illegal in dimensions string %s"
             % dimension_string)
     # Zero width or height not permitted
     if width <= 0 or height <= 0:
-        raise IIIFImageApiException(
+        raise ClientError(
             "Zero numbers illegal in dimensions string %s"
             % dimension_string)
     return (x, y, width, height)
@@ -44,26 +55,26 @@ def parse_width_height_string(wh_string):
     try:
         width, height = wh_string.split(',')
     except ValueError, ex:
-        raise IIIFImageApiException(
+        raise ClientError(
             "Cannot split width-height string %s: %s" % (wh_string, ex))
     # Parse width-height string sections into numerical values
     try:
         width = int(width) if width else None
         height = int(height) if height else None
     except ValueError, ex:
-        raise IIIFImageApiException(
+        raise ClientError(
             "Cannot parse numbers from width-height string %s: %s"
             % (wh_string, ex))
     # Sanity-checks for numerical values
     # At least one of width or height must be set
     if width is None and height is None:
-        raise IIIFImageApiException(
+        raise ClientError(
             "There must be a value in width-height string %s"
             % wh_string)
     # Negatives not permitted
     if (width is not None and width <= 0) or \
             (height is not None and height <= 0):
-        raise IIIFImageApiException(
+        raise ClientError(
             "Zero or negative numbers illegal in width-height string %s"
             % wh_string)
     return (width, height)
@@ -136,32 +147,32 @@ def parse_size(size, image_width, image_height):
 
 def parse_rotation(rotation_str, image_width, image_height):
     try:
-        rotation = int(rotation_str)
+        rotation = int(rotation_str) % 360
     except ValueError, ex:
-        raise IIIFImageApiException(
+        raise ClientError(
             "Cannot parse number from rotation string %s: %s"
             % (rotation_str, ex))
-    valid = (0, 360)
+    valid = (0,)
     if rotation not in valid:
-        raise IIIFImageApiException(
-            "Image API rotation parameters other than %r"
-            " are not yet supported %s" % (valid, rotation))
+        raise UnsupportedError(
+            "Image API rotation parameters other than %r degrees"
+            " are not yet supported: %s" % (valid, rotation))
     return rotation
 
 
 def parse_quality(quality):
     valid = ('default', 'color', 'gray',)
     if quality not in valid:
-        raise IIIFImageApiException(
+        raise UnsupportedError(
             "Image API quality parameters other than %r"
-            " are not yet supported %s" % (valid, quality))
+            " are not yet supported: %s" % (valid, quality))
     return quality
 
 
 def parse_format(output_format):
     valid = ('jpg',)
     if output_format not in valid:
-        raise IIIFImageApiException(
+        raise UnsupportedError(
             "Image API format parameters other than %r"
-            " are not yet supported %s" % (valid, output_format))
+            " are not yet supported: %s" % (valid, output_format))
     return output_format

--- a/icekit/plugins/iiif/views.py
+++ b/icekit/plugins/iiif/views.py
@@ -1,0 +1,47 @@
+from django.db.models.loading import get_model
+from django.http import Http404, HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+
+from fluent_utils.ajax import JsonResponse
+
+
+Image = get_model('icekit_plugins_image', 'Image')
+
+
+def _get_image_or_404(identifier):
+    """
+    Return image matching `identifier`.
+
+    The `identifier` is expected to be a raw image ID for now, but may be
+    more complex later.
+    """
+    return get_object_or_404(Image, id=identifier)
+
+
+# TODO Require privileged user
+def iiif_image_api_info(request, identifier):
+    """ Image Information endpoint for IIIF Image API 2.1 """
+    image = _get_image_or_404(identifier)
+    # TODO Return 'application/ld+json' response when requested
+    return JsonResponse({
+        "@context": "http://iiif.io/api/image/2/context.json",
+        "@id": request.get_full_path(),
+        "protocol": "http://iiif.io/api/image",
+        "width": image.width,
+        "height": image.height,
+        # TODO Return more complete info.json response per spec
+    })
+
+
+# TODO Require privileged user
+def iiif_image_api(request,
+                   identifier, region, size, rotation, quality, format
+):
+    """ Image repurposing endpoint for IIIF Image API 2.1 """
+    # TODO Redirect to canonical URL
+    image = _get_image_or_404(identifier)
+    # TODO Sanity-check image request parameters
+    # TODO Process image request parameters
+    # TODO Convert image
+    # TODO Set response content type
+    return None

--- a/icekit/plugins/iiif/views.py
+++ b/icekit/plugins/iiif/views.py
@@ -3,6 +3,7 @@ from easy_thumbnails.files import get_thumbnailer
 from django.db.models.loading import get_model
 from django.http import FileResponse
 from django.shortcuts import get_object_or_404
+from django.contrib.auth.decorators import permission_required
 
 from fluent_utils.ajax import JsonResponse
 
@@ -23,7 +24,7 @@ def _get_image_or_404(identifier):
     return get_object_or_404(Image, id=identifier)
 
 
-# TODO Require privileged user
+@permission_required('can_use_iiif_image_api')
 def iiif_image_api_info(request, identifier):
     """ Image Information endpoint for IIIF Image API 2.1 """
     image = _get_image_or_404(identifier)
@@ -38,7 +39,7 @@ def iiif_image_api_info(request, identifier):
     })
 
 
-# TODO Require privileged user
+@permission_required('can_use_iiif_image_api')
 def iiif_image_api(request,
                    identifier, region, size, rotation, quality, output_format):
     """ Image repurposing endpoint for IIIF Image API 2.1 """

--- a/icekit/plugins/iiif/views.py
+++ b/icekit/plugins/iiif/views.py
@@ -1,8 +1,13 @@
+from easy_thumbnails.files import get_thumbnailer
+
 from django.db.models.loading import get_model
-from django.http import Http404, HttpResponseRedirect
+from django.http import FileResponse
 from django.shortcuts import get_object_or_404
 
 from fluent_utils.ajax import JsonResponse
+
+from .utils import parse_region, parse_size, parse_rotation, parse_quality, \
+    parse_format
 
 
 Image = get_model('icekit_plugins_image', 'Image')
@@ -35,13 +40,42 @@ def iiif_image_api_info(request, identifier):
 
 # TODO Require privileged user
 def iiif_image_api(request,
-                   identifier, region, size, rotation, quality, format
-):
+                   identifier, region, size, rotation, quality, output_format):
     """ Image repurposing endpoint for IIIF Image API 2.1 """
     # TODO Redirect to canonical URL
     image = _get_image_or_404(identifier)
-    # TODO Sanity-check image request parameters
-    # TODO Process image request parameters
-    # TODO Convert image
-    # TODO Set response content type
-    return None
+    thumbnail_options = {}
+
+    # Apply region (actual work done in thumbnail generation below)
+    x, y, r_width, r_height = parse_region(region, image.width, image.height)
+
+    # Apply size (actual work done in thumbnail generation below)
+    s_width, s_height = parse_size(size, r_width, r_height)
+
+    # TODO Apply rotation
+    rotation = parse_rotation(rotation, s_width, s_height)
+
+    # Apply quality
+    quality = parse_quality(quality)
+    if quality in ('default', 'color'):
+        pass  # Nothing to do
+    elif quality == 'gray':
+        thumbnail_options['bw'] = True
+
+    # Generate image
+    # NOTE: Generates and saves a thumbnail to make subsequent lookups faster
+    thumbnail_options.update({
+        'crop': (x, y),
+        'size': (s_width, s_height),
+    })
+    thumbnailer = get_thumbnailer(image.image)
+    thumbnail = thumbnailer.get_thumbnail(thumbnail_options)
+
+    # TODO Apply format
+    output_format = parse_format(output_format)
+
+    # Set response content type
+    return FileResponse(
+        open(thumbnail.path, 'rb'),
+        content_type='image/%s' % output_format,
+    )

--- a/icekit/plugins/image/abstract_models.py
+++ b/icekit/plugins/image/abstract_models.py
@@ -1,12 +1,17 @@
+# -*- coding: utf-8 -*-
+
 from django.core.exceptions import ValidationError
 from django.template import Context
+from django.template.defaultfilters import filesizeformat
 from django.template.loader import render_to_string
+from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.db import models
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from fluent_contents.models import ContentItem
+from icekit.fields import QuietImageField
 
 
 @python_2_unicode_compatible
@@ -14,14 +19,16 @@ class AbstractImage(models.Model):
     """
     A reusable image.
     """
-    image = models.ImageField(
+    image = QuietImageField(
         upload_to='uploads/images/',
         verbose_name=_('Image file'),
+        width_field="width",
+        height_field="height",
     )
     title = models.CharField(
         max_length=255,
         blank=True,
-        help_text=_('Can be included in captions'),
+        help_text=_('You must specify either title or help text. Title can be included in captions.'),
     )
     alt_text = models.CharField(
         max_length=255,
@@ -31,17 +38,52 @@ class AbstractImage(models.Model):
     caption = models.TextField(
         blank=True,
     )
+    credit = models.CharField(
+        max_length=255,
+        blank=True,
+        help_text=_("Who or what to credit whenever the image is used."),
+    )
+    source = models.CharField(
+        max_length=255,
+        blank=True,
+        help_text=_("Where this image came from."),
+    )
     categories = models.ManyToManyField(
         'icekit.MediaCategory',
         blank=True,
         related_name='%(app_label)s_%(class)s_related',
     )
-    admin_notes = models.TextField(
+    license = models.TextField(
+        _('License/rights information'),
+        blank=True,
+    )
+    notes = models.TextField(
         blank=True,
         help_text=_('Internal notes for administrators only.'),
     )
-    is_active = models.BooleanField(
+
+    width = models.PositiveIntegerField(editable=False)
+    height = models.PositiveIntegerField(editable=False)
+
+    date_created = models.DateTimeField(
+        default=timezone.now,
+        editable=False
+    )
+    date_modified = models.DateTimeField(
+        auto_now=True,
+        editable=False
+    )
+
+    # Unused for now
+    is_ok_for_web = models.BooleanField(
+        _("OK for web"),
         default=True,
+    )
+
+    # Unused for now
+    maximum_dimension = models.PositiveIntegerField(
+        blank=True, null=True,
+        help_text=_("If the size of this image is to be limited to a particular size for distribution, note it here."),
     )
 
     def clean(self):
@@ -53,6 +95,21 @@ class AbstractImage(models.Model):
 
     def __str__(self):
         return self.title or self.alt_text
+
+    def dimensions(self):
+        if self.width and self.height:
+            # NB using the multiplication symbol ×, not the letter x
+            return u"%s × %s" % (self.width, self.heigh)
+        return None
+
+    def file_size(self):
+        """
+        Obtain the file size for the file in human readable format.
+
+        :return: String of file size with unit.
+        """
+        return filesizeformat(self.image.size)
+
 
 
 @python_2_unicode_compatible
@@ -71,6 +128,7 @@ class ImageLinkMixin(models.Model):
 
     title_override = models.CharField(max_length=512, blank=True)
     caption_override = models.TextField(blank=True)
+    # not allowing credit override yet
 
     caption_template = "icekit/plugins/image/_caption.html"
 
@@ -144,9 +202,21 @@ class ImageLinkMixin(models.Model):
         """
         self.title_override = ''
 
+    @property
+    def credit(self):
+        """
+        Obtains the credit override or the actual image title.
+
+        :return: Title text (safe).
+        """
+        if self.show_title:
+            return mark_safe(self.image.credit)
+        return None
+
     def displayed_caption(self):
         c = Context({'instance': self})
         return render_to_string(self.caption_template, c)
+
 
 @python_2_unicode_compatible
 class AbstractImageItem(ContentItem, ImageLinkMixin):

--- a/icekit/plugins/image/admin.py
+++ b/icekit/plugins/image/admin.py
@@ -1,5 +1,8 @@
 from django.contrib import admin
 from django.conf import settings
+from django.template import Context
+from django.template import Template
+from django.utils.safestring import mark_safe
 
 from icekit.utils.admin.mixins import ThumbnailAdminMixin
 
@@ -11,16 +14,61 @@ except (AttributeError, KeyError):
     ADMIN_THUMB_ALIAS = {'size': (150, 150)}
 
 class ImageAdmin(ThumbnailAdminMixin, admin.ModelAdmin):
-    list_display = ['thumbnail', 'title', 'alt_text',]
+    list_display = ['thumbnail', 'title', 'alt_text', 'is_ok_for_web', 'date_created', 'date_modified']
     list_display_links = ['alt_text', 'title', 'thumbnail']
+    date_hierarchy = 'date_modified'
     filter_horizontal = ['categories', ]
     list_filter = ['categories',]
-    search_fields = ['title', 'alt_text', 'caption', 'admin_notes', 'image']
+    search_fields = [
+        'title',
+        'alt_text',
+        'caption',
+        'image',
+        'credit',
+        'license',
+        'source',
+        'notes',
+    ]
+
+    fieldsets = (
+        (None, {
+            'fields': (
+                'image_tag',
+                'image',
+                'title',
+                'alt_text',
+                'caption',
+                ('dimensions', 'file_size'),
+            )
+        }),
+        ('Organization', {
+            'fields': ('categories', ('date_created', 'date_modified',) ),
+        }),
+        ('Usage', {
+            'fields': (
+                ('is_ok_for_web', 'maximum_dimension'),
+                'credit',
+                'license',
+                'source',
+                'notes',
+            ),
+        }),
+    )
+
+    readonly_fields = ('image_tag', 'file_size', 'dimensions', 'date_created', 'date_modified')
 
     change_form_template = 'image/admin/change_form.html'
 
     # ThumbnailAdminMixin attributes
     thumbnail_field = 'image'
     thumbnail_options = ADMIN_THUMB_ALIAS
+
+    def image_tag(self, obj):
+        t = Template("""{% load thumbnail %}<img src="{% thumbnail obj.image 500x500 %}">
+        """)
+        return mark_safe(t.render(Context({'obj': obj})))
+
+    image_tag.short_description = 'Image'
+
 
 admin.site.register(models.Image, ImageAdmin)

--- a/icekit/plugins/image/migrations/0010_auto_20170307_1458.py
+++ b/icekit/plugins/image/migrations/0010_auto_20170307_1458.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.utils.timezone
+import datetime
+from django.utils.timezone import utc
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('icekit_plugins_image', '0009_auto_20161026_2044'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='image',
+            old_name='admin_notes',
+            new_name='notes',
+        ),
+        migrations.RenameField(
+            model_name='image',
+            old_name='is_active',
+            new_name='is_ok_for_web',
+        ),
+        migrations.AddField(
+            model_name='image',
+            name='credit',
+            field=models.CharField(help_text='Who or what to credit whenever the image is used.', max_length=255, blank=True),
+        ),
+        migrations.AddField(
+            model_name='image',
+            name='date_created',
+            field=models.DateTimeField(default=django.utils.timezone.now, editable=False),
+        ),
+        migrations.AddField(
+            model_name='image',
+            name='date_modified',
+            field=models.DateTimeField(default=datetime.datetime(2017, 3, 7, 3, 58, 3, 483597, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='image',
+            name='height',
+            field=models.PositiveIntegerField(default=0, editable=False),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='image',
+            name='license',
+            field=models.TextField(verbose_name='License/rights information', blank=True),
+        ),
+        migrations.AddField(
+            model_name='image',
+            name='maximum_dimension',
+            field=models.PositiveIntegerField(help_text='If the size of this image is to be limited to a particular size for distribution, note it here.', null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='image',
+            name='source',
+            field=models.CharField(help_text='Where this image came from.', max_length=255, blank=True),
+        ),
+        migrations.AddField(
+            model_name='image',
+            name='width',
+            field=models.PositiveIntegerField(default=0, editable=False),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='image',
+            name='image',
+            field=models.ImageField(upload_to=b'uploads/images/', width_field=b'width', verbose_name='Image file', height_field=b'height'),
+        ),
+        migrations.AlterField(
+            model_name='image',
+            name='title',
+            field=models.CharField(help_text='You must specify either title or help text. Title can be included in captions.', max_length=255, blank=True),
+        ),
+    ]

--- a/icekit/plugins/image/templates/icekit/plugins/image/_caption.html
+++ b/icekit/plugins/image/templates/icekit/plugins/image/_caption.html
@@ -1,7 +1,8 @@
 {# used on the front end AND to preview in admin #}
 {% if instance.caption or instance.title %}
 	<figcaption class="image-caption">
-		{% if instance.title %}<h4>{{ instance.title }}</h4>{% endif %}
-		{% if instance.caption %}<p>{{ instance.caption }}</p>{% endif %}
+		{% if instance.title %}<h4 class="title">{{ instance.title }}</h4>{% endif %}
+		{% if instance.credit %}<p class="credit">{{ instance.credit }}</p>{% endif %}
+		{% if instance.caption %}<p class="title">{{ instance.caption }}</p>{% endif %}
 	</figcaption>
 {% endif %}

--- a/icekit/project/glamkit_urls.py
+++ b/icekit/project/glamkit_urls.py
@@ -4,4 +4,5 @@ from django.conf.urls import include, patterns, url
 # inject just before the final catch-all
 urlpatterns = urlpatterns[:-1] + patterns('',
     url(r'^events/', include('icekit_events.urls')),
+    url(r'^iiif/', include('icekit.plugins.iiif.urls')),
 ) + urlpatterns[-1:]

--- a/icekit/project/settings/glamkit.py
+++ b/icekit/project/settings/glamkit.py
@@ -5,6 +5,7 @@ from .icekit import *
 INSTALLED_APPS += (
     'sponsors',
     'press_releases',
+    'icekit.plugins.iiif',
 
     'icekit_events',
     'icekit_events.event_types.simple',

--- a/project_template/project_settings.py
+++ b/project_template/project_settings.py
@@ -4,6 +4,6 @@
 # Additional environment variables will be loaded from `.env.$DOTENV`.
 # Local settings will be imported from `project_settings_local.py`
 
-from icekit.project.settings.icekit import *  # glamkit, icekit
+from icekit.project.settings.glamkit import *  # glamkit, icekit
 
 # Override the default ICEkit settings to form project settings.


### PR DESCRIPTION
Add "iiif" app to GLAMkit to support key features of the [IIIF Image API (version 2.1)](http://iiif.io/api/image/2.1/#format) to return image information and to repurpose images by resizing, cropping, and converting formats.

This feature allows privileged users (with `can_use_iiif_image_api` permission) to repurpose images using URL paths like:
* /iiif/ID/full/max/0/default.png
* /iiif/ID/square/max/0/default.jpg
* /iiif/ID/full/!400,300/0/default.tif
* /iiif/ID/100,150,900,600/300,/0/default.png
* etc

NOTES:
* This PR includes work done on the "feature/image_improvements" branch
* Includes commit f019902 that enables GLAMkit features by default in new ICEkit projects, instead of only core ICEkit features.