### PR TITLE
Add staging class to the admin body if '(staging)' exists in the site name

### DIFF
--- a/icekit/dashboard/static/admin/css/icekit_dashboard.less
+++ b/icekit/dashboard/static/admin/css/icekit_dashboard.less
@@ -15,6 +15,15 @@ body {
   padding-bottom: @footer-height;
 }
 
+.staging::before {
+    content: "You are currently working on a staging site!";
+    text-align: center;
+    display: block;
+    padding: 1em;
+    background-color: #fde149;
+    color: #333;
+}
+
 #container {
     min-width: auto;
 }

--- a/icekit/dashboard/templates/admin/base_site.html
+++ b/icekit/dashboard/templates/admin/base_site.html
@@ -32,6 +32,12 @@
 	{% endcompress %}
 {% endblock %}
 
+{% block bodyclass %}{{ block.super }}
+    {% if "(staging)" in SITE_NAME.lower %}
+        staging
+    {% endif %}
+{% endblock %}
+
 {% block branding %}
 	<a href="{% url 'admin:index' %}">
 		<img id="site-logo" src="{% block header-image %}{% static 'admin/img/header-brand.png' %}{% endblock header-image %}" title="{{ SITE_NAME }}">


### PR DESCRIPTION
This is (one possible) solution to adding a banner to the admin if the `SITE_NAME` constant includes the string `(staging)` with a case insensitive check. The approach I've gone for is adding a class to the body element in the admin, and using CSS on a pseudo element to create the banner, since I couldn't find a clean way to add a block as the very first element in the Django admin.

I just grabbed the background colour from the IC logo for consistency, but we're not too concerned about the colour / style of the banner, just that it's prominent. Here's an example:

![image](https://cloud.githubusercontent.com/assets/14988353/23932964/61d80bca-098f-11e7-8be0-1d49553e98bc.png)

cc @cogat