### PR TITLE
Use public-read for S3-enabled storage of thumbnails by default

### DIFF
--- a/icekit/project/settings/calculated.py
+++ b/icekit/project/settings/calculated.py
@@ -126,6 +126,10 @@ if RAVEN_CONFIG.get('dsn'):
 
 # STORAGES ####################################################################
 
+# Override media and thumbnail storage if S3 media is enabled
 if ENABLE_S3_MEDIA:
-    DEFAULT_FILE_STORAGE = 'icekit.utils.storage.S3DefaultStorage'
-    THUMBNAIL_DEFAULT_STORAGE = DEFAULT_FILE_STORAGE
+    # "Private" S3 storage by default for most media assets
+    DEFAULT_FILE_STORAGE = 'icekit.utils.storage.S3DefaultPrivateStorage'
+
+    # "Public" S3 storage by default for thumbnails
+    THUMBNAIL_DEFAULT_STORAGE = 'icekit.utils.storage.S3DefaultPublicStorage'

--- a/icekit/utils/storage.py
+++ b/icekit/utils/storage.py
@@ -54,13 +54,26 @@ class S3StaticLocationMixin(object):
 # STORAGE CLASSES #############################################################
 
 
-class S3DefaultStorage(
+class S3DefaultPrivateStorage(
         # HashedMediaMixin,
         S3MediaLocationMixin,
         S3PrivateMixin,
         S3Boto3Storage):
 
     pass
+
+
+class S3DefaultPublicStorage(
+        # HashedMediaMixin,
+        S3MediaLocationMixin,
+        S3PublicMixin,
+        S3Boto3Storage):
+
+    pass
+
+
+# TODO Deprecated, use `S3DefaultPrivateStorage` instead of `S3DefaultStorage`
+S3DefaultStorage = S3DefaultPrivateStorage
 
 
 default_storage = get_storage_class(settings.DEFAULT_FILE_STORAGE)()


### PR DESCRIPTION
When the `ENABLE_S3_MEDIA` setting is applied, continue to use "private"
S3 storage for media assets by default, but switch to using "public"
S3 storage for thumbnails generated by the thumbnailing system.

Here "private" storage means that images are only accessible through
time-limited signed S3 URLs, while "public" means that thumbnails will
be accessible through non-time-limited standard S3 URLs and the
thumbnail images will be stored with the `public-read` ACL behind the
scenes.

As part of this change, the `S3DefaultStorage` storage class is renamed
to `S3DefaultPrivateStorage` to be explicit (the original class name
remains available for backwards-compatibility) and the new
`S3DefaultPublicStorage` class is added.