### PR TITLE
Text plugin DB migrations unchanged by different settings

### DIFF
--- a/icekit/plugins/text/migrations/.gitignore
+++ b/icekit/plugins/text/migrations/.gitignore
@@ -1,2 +1,0 @@
-# migrations created if CHOICES changes in a downstream project
-0003_auto*.py

--- a/icekit/plugins/text/migrations/0002_textitem_style.py
+++ b/icekit/plugins/text/migrations/0002_textitem_style.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
+from icekit.plugins.text import appsettings
+
 
 class Migration(migrations.Migration):
 
@@ -14,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='textitem',
             name='style',
-            field=models.CharField(blank=True, max_length=255, choices=[(b'', b'Normal')]),
+            field=models.CharField(blank=True, max_length=255, choices=appsettings.TEXT_STYLE_CHOICES),
         ),
     ]


### PR DESCRIPTION
Changing the `TEXT_STYLE_CHOICES` of the Text plugin in
downstream projects will no longer cause extra spurious
DB migrations to be generated due to supposed changes to
the `style` attribute.