### PR TITLE
#176 Remove unneeded unpublishable model variants

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Develop
+-------
+
+-  Remove unpublishable variants of the main GLAMkit models as keeping them is
+   not worth the maintenance overhead or chance for confusion.
+
 0.17 (2017-04-30)
 -----------------
 

--- a/icekit/page_types/layout_page/abstract_models.py
+++ b/icekit/page_types/layout_page/abstract_models.py
@@ -1,15 +1,7 @@
-from fluent_pages.integration.fluent_contents import FluentContentsPage
-
 from icekit.models import ICEkitFluentContentsPageMixin
 from icekit.mixins import LayoutFieldMixin, HeroMixin, ListableMixin
-from icekit.plugins.descriptors import contribute_to_class as contribute_placeholder_descriptor_to_class
-
-
-class AbstractUnpublishableLayoutPage(FluentContentsPage, LayoutFieldMixin):
-    class Meta:
-        abstract = True
-
-contribute_placeholder_descriptor_to_class(AbstractUnpublishableLayoutPage, name='slots')
+from icekit.plugins.descriptors import \
+    contribute_to_class as contribute_placeholder_descriptor_to_class
 
 
 class AbstractLayoutPage(ICEkitFluentContentsPageMixin, LayoutFieldMixin,

--- a/icekit/page_types/layout_page/admin.py
+++ b/icekit/page_types/layout_page/admin.py
@@ -1,12 +1,9 @@
-from fluent_pages.integration.fluent_contents.admin import FluentContentsPageAdmin
+from fluent_pages.integration.fluent_contents.admin \
+    import FluentContentsPageAdmin
 
 from icekit.admin_tools.mixins import FluentLayoutsMixin, HeroMixinAdmin, \
     ListableMixinAdmin
 from icekit.admin import ICEkitContentsAdmin
-
-
-class UnpublishableLayoutPageAdmin(FluentLayoutsMixin, FluentContentsPageAdmin):
-    raw_id_fields = ('parent',)
 
 
 class LayoutPageAdmin(

--- a/icekit/page_types/search_page/abstract_models.py
+++ b/icekit/page_types/search_page/abstract_models.py
@@ -1,17 +1,14 @@
 from django.db import models
-from fluent_pages.integration.fluent_contents import FluentContentsPage
 from icekit.mixins import ListableMixin
 from icekit.models import ICEkitFluentContentsPageMixin
 
 
-class AbstractUnpublishableSearchPage(FluentContentsPage, ListableMixin):
-    class Meta:
-        abstract = True
-        verbose_name = 'Search page'
-
-
 class AbstractSearchPage(ICEkitFluentContentsPageMixin, ListableMixin):
-    default_search_type = models.CharField(max_length=255, blank=True, help_text="Default to a top-level result type, e.g 'Education'. This value must be one of the top-level facets.")
+    default_search_type = models.CharField(
+        max_length=255,
+        blank=True,
+        help_text="Default to a top-level result type, e.g 'Education'."
+                  " This value must be one of the top-level facets.")
 
     class Meta:
         abstract = True

--- a/icekit/page_types/search_page/admin.py
+++ b/icekit/page_types/search_page/admin.py
@@ -1,10 +1,7 @@
-from fluent_pages.integration.fluent_contents.admin import FluentContentsPageAdmin
+from fluent_pages.integration.fluent_contents.admin \
+    import FluentContentsPageAdmin
 
 from icekit.admin import ICEkitContentsAdmin
-
-
-class UnpublishableSearchPageAdmin(FluentContentsPageAdmin):
-    placeholder_layout_template = 'icekit/page_types/search_page/default.html'
 
 
 class SearchPageAdmin(FluentContentsPageAdmin, ICEkitContentsAdmin):

--- a/icekit/plugins/slideshow/abstract_models.py
+++ b/icekit/plugins/slideshow/abstract_models.py
@@ -1,6 +1,5 @@
 from django.db import models
 from django.template import Context
-from django.template import RequestContext
 from django.template import Template
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
@@ -13,7 +12,7 @@ from . import appsettings
 
 
 @python_2_unicode_compatible
-class AbstractUnpublishableSlideShow(models.Model):
+class AbstractSlideShow(ICEkitContentsMixin):
     """
     A reusable Slide Show.
     """
@@ -51,18 +50,6 @@ class AbstractUnpublishableSlideShow(models.Model):
             'obj': self,
         })
         return t.render(c)
-
-
-@python_2_unicode_compatible
-class AbstractSlideShow(AbstractUnpublishableSlideShow, ICEkitContentsMixin):
-
-    class Meta:
-        abstract = True
-        verbose_name = "Image gallery"
-        verbose_name_plural = "Image galleries"
-
-    def __str__(self):
-        return self.title
 
 
 @python_2_unicode_compatible

--- a/icekit/publishing/tests.py
+++ b/icekit/publishing/tests.py
@@ -13,8 +13,6 @@ from django.test import TestCase, TransactionTestCase, RequestFactory
 from django.test.utils import override_settings, modify_settings
 from django.utils import timezone
 
-from django_webtest import WebTest
-
 from mock import patch, Mock
 
 from django_dynamic_fixture import G
@@ -39,7 +37,7 @@ from icekit.publishing.utils import get_draft_hmac, verify_draft_url, \
     get_draft_url, PublishingException, NotDraftException
 from icekit.publishing.tests_base import BaseAdminTest
 from icekit.tests.models import LayoutPageWithRelatedPages, \
-    UnpublishableLayoutPage, Article, ArticleListing, PublishingM2MModelA, \
+    Article, ArticleListing, PublishingM2MModelA, \
     PublishingM2MModelB, PublishingM2MThroughTable
 
 User = get_user_model()
@@ -1494,18 +1492,6 @@ class TestPublishingForPageViews(BaseAdminTest):
             self.layoutpage,
             html='<b>test content instance</b>'
         )
-        # UnpublishableLayoutPage is not a PublishingModel
-        self.unpublishablelayoutpage = UnpublishableLayoutPage.objects.create(
-            author=self.super_user,
-            title='Test Unpublishable LayoutPage',
-            layout=self.layout,
-            status=UrlNode.DRAFT,
-        )
-        self.content_instance = fluent_contents.create_content_instance(
-            RawHtmlItem,
-            self.unpublishablelayoutpage,
-            html='<b>test content instance</b>'
-        )
 
     def test_url_routing_for_draft_and_published_copies(self):
         # Unpublished page is not visible to anonymous users
@@ -1603,43 +1589,6 @@ class TestPublishingForPageViews(BaseAdminTest):
         # Published page is visible to anonymous users
         response = self.app.get(
             self.layoutpage.get_absolute_url(),
-            user=self.normal_user)
-        self.assertEqual(response.status_code, 200)
-
-    # This is a duplicate of `test_verified_draft_url_for_publishingmodel` but
-    # for a non-publishable model instead, to ensure verified draft URLs work
-    # in all cases.
-    def test_verified_draft_url_for_non_publishingmodel(self):
-        # Unpublished page is not visible to anonymous users
-        response = self.app.get(
-            self.unpublishablelayoutpage.get_absolute_url(),
-            user=self.normal_user,
-            expect_errors=True)
-        self.assertEqual(response.status_code, 404)
-        # Unpublished page is visible to staff user with '?edit' param redirect
-        response = self.app.get(
-            self.unpublishablelayoutpage.get_absolute_url(),
-            user=self.super_user)
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue('?edit=' in response['Location'])
-        response = response.follow()
-        self.assertEqual(response.status_code, 200)
-        # Unpublished page is visible to any user with signed '?edit' param
-        salt = '123'
-        url_hmac = get_draft_hmac(salt, self.unpublishablelayoutpage.get_absolute_url())
-        response = self.app.get(
-            self.unpublishablelayoutpage.get_absolute_url() + '?edit=%s:%s' % (
-                salt, url_hmac),
-            user=self.normal_user)
-        self.assertEqual(response.status_code, 200)
-
-        # Publish page by changing status (no `published()` method)
-        self.unpublishablelayoutpage.status = UrlNode.PUBLISHED
-        self.unpublishablelayoutpage.save()
-
-        # Published page is visible to anonymous users
-        response = self.app.get(
-            self.unpublishablelayoutpage.get_absolute_url(),
             user=self.normal_user)
         self.assertEqual(response.status_code, 200)
 

--- a/icekit/tests/migrations/0010_auto_20170522_1600.py
+++ b/icekit/tests/migrations/0010_auto_20170522_1600.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fluent_pages', '0001_initial'),
+        ('tests', '0009_auto_20170519_1232'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='unpublishablelayoutpage',
+            name='layout',
+        ),
+        migrations.RemoveField(
+            model_name='unpublishablelayoutpage',
+            name='urlnode_ptr',
+        ),
+        migrations.AlterModelOptions(
+            name='publishingm2mmodela',
+            options={'permissions': (('can_publish', 'Can publish'), ('can_republish', 'Can republish'))},
+        ),
+        migrations.AlterModelOptions(
+            name='publishingm2mmodelb',
+            options={'permissions': (('can_publish', 'Can publish'), ('can_republish', 'Can republish'))},
+        ),
+        migrations.DeleteModel(
+            name='UnpublishableLayoutPage',
+        ),
+    ]

--- a/icekit/tests/models.py
+++ b/icekit/tests/models.py
@@ -1,8 +1,6 @@
 """
 Test models for ``icekit`` app.
 """
-from urlparse import urljoin
-
 from django.db import models
 from django.http import HttpResponse
 
@@ -14,11 +12,11 @@ from icekit.content_collections.abstract_models import AbstractListingPage, \
     AbstractCollectedContent, TitleSlugMixin
 from icekit.content_collections.page_type_plugins import ListingPagePlugin
 
-from icekit.page_types.layout_page.abstract_models import \
-    AbstractLayoutPage, AbstractUnpublishableLayoutPage
+from icekit.page_types.layout_page.abstract_models import AbstractLayoutPage
 from icekit.publishing.models import PublishingModel
 from icekit.plugins import ICEkitFluentContentsPagePlugin
 from icekit import mixins
+
 
 class BaseModel(abstract_models.AbstractBaseModel):
     """
@@ -58,7 +56,8 @@ class ArticleListing(AbstractListingPage):
         db_table = 'test_articlelisting'
 
 
-class Article(AbstractCollectedContent, PublishableFluentContents, TitleSlugMixin):
+class Article(AbstractCollectedContent, PublishableFluentContents,
+              TitleSlugMixin):
     """Articles that belong to a particular listing"""
     parent = models.ForeignKey(
         ArticleListing,
@@ -88,16 +87,6 @@ class LayoutPageWithRelatedPagesPlugin(ICEkitFluentContentsPagePlugin):
     """
     model = LayoutPageWithRelatedPages
     render_template = 'icekit/page_types/article/default.html'
-
-
-class UnpublishableLayoutPage(AbstractUnpublishableLayoutPage):
-    pass
-
-
-@page_type_pool.register
-class UnpublishableLayoutPagePlugin(ICEkitFluentContentsPagePlugin):
-    model = UnpublishableLayoutPage
-    render_template = 'icekit/layouts/default.html'
 
 
 @page_type_pool.register


### PR DESCRIPTION
We will not support unpublishable variants of the main
GLAMkit models as it isn't worth the overhead or chance
for confusion.

This change removes "unpublishable" models.