### PR TITLE
Swap twitter card default in base.html to summary card type

### DIFF
--- a/icekit/templates/icekit/base.html
+++ b/icekit/templates/icekit/base.html
@@ -22,7 +22,7 @@
 					<meta property="og:image" content="{% block og_image %}{% with page.get_og_image_url as og_image %}{% if og_image %}{{ og_image|safe }}{% endif %}{% endwith %}{% endblock %}">
 					<meta property="og:site_name" content="{% block og_site_name %}{{ SITE_NAME }}{% endblock %}">
 					<meta property="og:description" content="{% block og_description %}{{ page.get_og_description }}{% endblock %}">
-					<meta name="twitter:card" content="{% block twitter_card %}summary_large_card{% endblock %}" />
+					<meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}" />
 					<meta name="twitter:site" content="{% block twitter_site %}{{ SITE_TWITTER_USERNAME }}{% endblock %}" />
 					<meta name="twitter:creator" content="{% block twitter_creator %}{{ SITE_TWITTER_USERNAME }}{% endblock %}" />
 					<meta name="twitter:title" content="{% block twitter_title %}{{ page.get_og_title }}{% endblock %}" />


### PR DESCRIPTION
I've done a bit of work recently at ACMI on getting Twitter cards to work nicely. This PR is to swap the default card type to a [Summary card type](https://dev.twitter.com/cards/types/summary), which is possibly a better default type as it uses square thumbnails so might be a better crop for most images. I'd recommend using this as a default in the icekit repo, and have orgs override it if they'd prefer a different card type.