### PR TITLE
Compartmentalise icekit's bower deps

### DIFF
--- a/icekit/.bowerrc
+++ b/icekit/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory" : "static/icekit/bower_components"
+}

--- a/icekit/admin_tools/templates/admin/base_site.html
+++ b/icekit/admin_tools/templates/admin/base_site.html
@@ -23,7 +23,7 @@
 		<link type="text/less" rel="stylesheet" href="{% static 'admin/css/icekit_dashboard.less' %}" />
 		<link type="text/less" rel="stylesheet" href="{% static 'admin/css/override.less' %}" />
 	{% endcompress %}
-	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
+	<link rel="stylesheet" href="{% static 'icekit/bower_components/font-awesome/css/font-awesome.css' %}">
 {% endblock %}
 
 {% block extrahead %}

--- a/icekit/admin_tools/templates/admin/base_site.html
+++ b/icekit/admin_tools/templates/admin/base_site.html
@@ -18,7 +18,7 @@
 	{% compress css %}
 		{# Bootstrap, then default admin styles, then our styles. #}
 		{# This avoids overriding the admin with Bootstrap, and allows us to override anything. #}
-		<link rel="stylesheet" href="{% static 'bootstrap/dist/css/bootstrap.css' %}" />
+		<link rel="stylesheet" href="{% static 'icekit/bower_components/bootstrap/dist/css/bootstrap.css' %}" />
 		<link rel="stylesheet" href="{% static 'admin/css/base.css' %}" />
 		<link type="text/less" rel="stylesheet" href="{% static 'admin/css/icekit_dashboard.less' %}" />
 		<link type="text/less" rel="stylesheet" href="{% static 'admin/css/override.less' %}" />
@@ -28,8 +28,8 @@
 
 {% block extrahead %}
 	{% compress js %}
-		<script src="{% static 'jquery/dist/jquery.js' %}"></script>
-		<script src="{% static 'bootstrap/dist/js/bootstrap.js' %}"></script>
+		<script src="{% static 'icekit/bower_components/jquery/dist/jquery.js' %}"></script>
+		<script src="{% static 'icekit/bower_components/bootstrap/dist/js/bootstrap.js' %}"></script>
 	{% endcompress %}
 {% endblock %}
 

--- a/icekit/bin/setup-django.sh
+++ b/icekit/bin/setup-django.sh
@@ -26,8 +26,11 @@ fi
 # Install Node modules.
 waitlock.sh npm-install.sh "$ICEKIT_PROJECT_DIR"
 
-# Install Bower components.
+# Install Bower components for the project.
 waitlock.sh bower-install.sh "$ICEKIT_PROJECT_DIR"
+
+# Install Bower components for icekit.
+waitlock.sh bower-install.sh "$ICEKIT_DIR"
 
 # Install Python requirements.
 waitlock.sh pip-install.sh "$ICEKIT_PROJECT_DIR"

--- a/icekit/bower.json
+++ b/icekit/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "icekit",
+  "dependencies": {
+    "alloyeditor": "^1.2.3",
+    "bootstrap": "^3.3.7",
+    "eonasdan-bootstrap-datetimepicker": "^4.17.47",
+    "font-awesome": "^4.6.3",
+    "jquery": "^3.1.0",
+    "lodash": "^4.14.2",
+		"jquery-ui": "^1.11.4",
+		"fullcalendar": "^3.0.1",
+		"iframe-resizer": "^2.8.7",
+		"skveege-rrule": "^2.1.3",
+		"js-cookie": "^2.1.3"
+  },
+  "private": true
+}

--- a/icekit/plugins/location/templates/icekit/plugins/location/location.html
+++ b/icekit/plugins/location/templates/icekit/plugins/location/location.html
@@ -68,7 +68,7 @@
 
 	{% block base_js %}
 		{{ block.super }}
-		<script src="{% static 'lodash/lodash.js' %}"></script>
-		<script src="{% static 'icekit/js/google_map.js' %}"></script>
+		<script src="{% static 'icekit/bower_components/lodash/lodash.js' %}"></script>
+		<script src="{% static 'icekit/bower_components/icekit/js/google_map.js' %}"></script>
 	{% endblock %}
 {% endblock body %}

--- a/icekit/project/settings/_base.py
+++ b/icekit/project/settings/_base.py
@@ -513,7 +513,7 @@ INSTALLED_APPS += ('flat', )
 # DJANGO_WYSIWYG_MEDIA_URL = '/'  # See redirects in `icekit.project.urls`
 
 DJANGO_WYSIWYG_FLAVOR = 'alloyeditor'
-DJANGO_WYSIWYG_MEDIA_URL = STATIC_URL + 'alloyeditor/dist/alloy-editor/'
+DJANGO_WYSIWYG_MEDIA_URL = STATIC_URL + 'icekit/bower_components/alloyeditor/dist/alloy-editor/'
 
 BASIC_PLUGINS = [
     'RawHtmlPlugin',

--- a/icekit/templates/icekit/base.html
+++ b/icekit/templates/icekit/base.html
@@ -43,8 +43,8 @@
 				{# Base CSS files #}
 				{% compress css file %}
                     {% block icekit_css %}
-						<link rel="stylesheet" href="{% static 'bootstrap/dist/css/bootstrap.css' %}">
-						<link rel="stylesheet" href="{% static 'font-awesome/css/font-awesome.css' %}">
+						<link rel="stylesheet" href="{% static 'icekit/bower_components/bootstrap/dist/css/bootstrap.css' %}">
+						<link rel="stylesheet" href="{% static 'icekit/bower_components/font-awesome/css/font-awesome.css' %}">
 						<link rel="stylesheet" type="text/x-scss" href="{% static 'icekit/styles/icekit.scss' %}">
 					{% endblock %}
                     {# Default styling for a project, designed to be overridden once a build is underway #}
@@ -86,8 +86,8 @@
 			{# Base JS files #}
 			{% compress js file %}
 				{% block base_js %}
-					<script src="{% static 'jquery/dist/jquery.min.js' %}"></script>
-					<script src="{% static 'icekit/js/link_share.js' %}"></script>
+					<script src="{% static 'icekit/bower_components/jquery/dist/jquery.min.js' %}"></script>
+					<script src="{% static 'icekit/bower_components/icekit/js/link_share.js' %}"></script>
 				{% endblock %}
 			{% endcompress %}
 			{# Extra JS files - section/page specific, etc #}

--- a/icekit_events/admin.py
+++ b/icekit_events/admin.py
@@ -193,7 +193,7 @@ class EventAdmin(ChildModelPluginPolymorphicParentModelAdmin,
 
     class Media:
         css = {
-            'all': ('font-awesome/css/font-awesome.css',),
+            'all': ('icekit/bower_components/font-awesome/css/font-awesome.css',),
         }
 
     def get_queryset(self, request):

--- a/icekit_events/forms.py
+++ b/icekit_events/forms.py
@@ -26,9 +26,9 @@ class RecurrenceRuleWidget(forms.MultiWidget):
             'all': ('icekit_events/css/recurrence_rule_widget.css', ),
         }
         js = (
-            'lodash/lodash.js',
-            'skveege-rrule/lib/rrule.js',
-            'skveege-rrule/lib/nlp.js',
+            'icekit/bower_components/lodash/lodash.js',
+            'icekit/bower_components/skveege-rrule/lib/rrule.js',
+            'icekit/bower_components/skveege-rrule/lib/nlp.js',
         )
 
     def __init__(self, *args, **kwargs):

--- a/icekit_events/page_types/advancedeventlisting/templates/advancedeventlisting/layouts/default.html
+++ b/icekit_events/page_types/advancedeventlisting/templates/advancedeventlisting/layouts/default.html
@@ -6,7 +6,7 @@
 
 {% block css %}
     {{ block.super }}
-    <link rel="stylesheet" href="{% static 'jquery-ui/themes/base/jquery-ui.css' %}">
+    <link rel="stylesheet" href="{% static 'icekit/bower_components/jquery-ui/themes/base/jquery-ui.css' %}">
 {% endblock %}
 
 {% block content %}
@@ -74,7 +74,7 @@
 {% block js %}
     {{ block.super }}
     <script src="{% static 'icekit_events/js/jquery-querystring.js' %}"></script>
-    <script src="{% static 'jquery-ui/jquery-ui.min.js' %}"></script>
+    <script src="{% static 'icekit/bower_components/jquery-ui/jquery-ui.min.js' %}"></script>
 
     {# Configure behaviour of start/end field datepicker widgets #}
     <script>

--- a/icekit_events/page_types/eventlistingfordate/templates/eventlistingfordate/layouts/default.html
+++ b/icekit_events/page_types/eventlistingfordate/templates/eventlistingfordate/layouts/default.html
@@ -36,7 +36,7 @@
 {% block js %}
     {{ block.super }}
     <script src="{% static 'icekit_events/js/jquery-querystring.js' %}"></script>
-    <script src="{% static 'jquery-ui/jquery-ui.min.js' %}"></script>
+    <script src="{% static 'icekit/bower_components/jquery-ui/jquery-ui.min.js' %}"></script>
     <script src="{% static 'icekit_events/js/events_datepicker.js' %}"></script>
 {% endblock %}
 

--- a/icekit_events/templates/admin/icekit_events/eventbase/calendar.html
+++ b/icekit_events/templates/admin/icekit_events/eventbase/calendar.html
@@ -4,7 +4,7 @@
 
 <html>
 	<head>
-		<link rel='stylesheet' href='{% static "fullcalendar/dist/fullcalendar.css" %}' />
+		<link rel='stylesheet' href='{% static "icekit/bower_components/fullcalendar/dist/fullcalendar.css" %}' />
 		<style>
 			html, body {
 				/*height: 100%;*/
@@ -44,11 +44,11 @@
 				opacity: 0.4;
 			}
 		</style>
-		<script src='{% static "jquery/dist/jquery.js" %}'></script>
-		<script src='{% static "moment/moment.js" %}'></script>
-		<script src='{% static "fullcalendar/dist/fullcalendar.min.js" %}'></script>
-		<script src='{% static "iframe-resizer/src/iframeResizer.contentWindow.js" %}'></script>
-		<script src='{% static "js-cookie/src/js.cookie.js" %}'></script>
+		<script src='{% static "icekit/bower_components/jquery/dist/jquery.js" %}'></script>
+		<script src='{% static "icekit/bower_components/moment/moment.js" %}'></script>
+		<script src='{% static "icekit/bower_components/fullcalendar/dist/fullcalendar.min.js" %}'></script>
+		<script src='{% static "icekit/bower_components/iframe-resizer/src/iframeResizer.contentWindow.js" %}'></script>
+		<script src='{% static "icekit/bower_components/js-cookie/src/js.cookie.js" %}'></script>
 
 		<script>
 			var icekit_events = icekit_events || {};

--- a/icekit_events/templates/admin/icekit_events/eventbase/change_form.html
+++ b/icekit_events/templates/admin/icekit_events/eventbase/change_form.html
@@ -20,8 +20,8 @@
 			}
 
 		</style>
-		<script src='{% static "iframe-resizer/src/iframeResizer.js" %}'></script>
-		<script src='{% static "js-cookie/src/js.cookie.js" %}'></script>
+		<script src='{% static "icekit/bower_components/iframe-resizer/src/iframeResizer.js" %}'></script>
+		<script src='{% static "icekit/bower_components/js-cookie/src/js.cookie.js" %}'></script>
 
 		<div id="calendar-container">
 

--- a/icekit_events/templates/admin/icekit_events/eventbase/change_list.html
+++ b/icekit_events/templates/admin/icekit_events/eventbase/change_list.html
@@ -20,8 +20,8 @@
 				width: 100%;
 			}
 		</style>
-		<script src='{% static "iframe-resizer/src/iframeResizer.js" %}'></script>
-		<script src='{% static "js-cookie/src/js.cookie.js" %}'></script>
+		<script src='{% static "icekit/bower_components/iframe-resizer/src/iframeResizer.js" %}'></script>
+		<script src='{% static "icekit/bower_components/js-cookie/src/js.cookie.js" %}'></script>
 		<div class="results">
 			<iframe id="calendar" src="{% url "admin:icekit_events_eventbase_calendar" %}?{{ request.GET.urlencode }}" scrolling="no"></iframe>
 			<script>

--- a/project_template/bower.json
+++ b/project_template/bower.json
@@ -1,17 +1,10 @@
 {
   "name": "project_template",
   "dependencies": {
-    "alloyeditor": "^1.2.3",
     "bootstrap": "^3.3.7",
-    "eonasdan-bootstrap-datetimepicker": "^4.17.47",
     "font-awesome": "^4.6.3",
     "jquery": "^3.1.0",
-    "lodash": "^4.14.2",
-		"jquery-ui": "~1.11.4",
-		"fullcalendar": "^3.0.1",
-		"iframe-resizer": "~2.8.7",
-		"skveege-rrule": "~2.1.3",
-		"js-cookie": "^2.1.3"
+    "lodash": "^4.14.2"
   },
   "private": true
 }


### PR DESCRIPTION
Re: #286 

The intention here is to keep all of icekit's deps within icekit itself, so that the project can define common url paths ("bootstrap/...", for example) without impacting on the admin's functionality.

Basically, we've added another `bower-install.sh` invocation, which targets the `icekit` dir. There's a `.bowerrc` file that tells bower to install all of the deps into a `icekit/bower_components` dir within icekit's static dir. All of the asset references have been updated to target that directory.